### PR TITLE
Fix `disabled` button style for both themes

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.0-rc4",
+  "version": "0.1.0-rc5",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.0-rc3",
+  "version": "0.1.0-rc4",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/Button/index.tsx
+++ b/main/Button/index.tsx
@@ -35,6 +35,7 @@ const ButtonContainer = styled.View<{
   type: ButtonType;
   size?: ButtonSize;
   outlined?: boolean;
+  disabled?: boolean;
 }>`
   align-self: stretch;
   padding: ${({size}) =>
@@ -45,8 +46,10 @@ const ButtonContainer = styled.View<{
       : '10px 20px'};
   border-radius: ${({size}) => (size === 'large' ? '24px' : '20px')};
   border-width: ${({outlined}) => (outlined ? '1px' : 0)};
-  background-color: ${({theme, type, outlined}) =>
-    outlined
+  background-color: ${({theme, type, outlined, disabled}) =>
+    disabled
+      ? undefined
+      : outlined
       ? theme.background
       : type === 'info'
       ? theme.info
@@ -57,8 +60,10 @@ const ButtonContainer = styled.View<{
       : type === 'warning'
       ? theme.warning
       : theme.primary};
-  border-color: ${({theme, type}) =>
-    type === 'info'
+  border-color: ${({theme, type, disabled}) =>
+    disabled
+      ? undefined
+      : type === 'info'
       ? theme.info
       : type === 'secondary'
       ? theme.secondary
@@ -115,24 +120,25 @@ const StyledButton: FC<ButtonProps & {theme: DoobooTheme}> = ({
   const hovered = useHover(ref);
   const [layout, setLayout] = useState<LayoutRectangle>();
 
-  const mainColor =
-    type === 'info'
-      ? theme.info
-      : type === 'secondary'
-      ? theme.secondary
-      : type === 'danger'
-      ? theme.danger
-      : type === 'warning'
-      ? theme.warning
-      : theme.primary;
+  const mainColor = disabled
+    ? theme.disabled
+    : type === 'info'
+    ? theme.info
+    : type === 'secondary'
+    ? theme.secondary
+    : type === 'danger'
+    ? theme.danger
+    : type === 'warning'
+    ? theme.warning
+    : theme.primary;
 
   const compositeStyles: Styles = {
     disabledButton: {
-      backgroundColor: theme.disabled,
+      backgroundColor: !outlined ? theme.disabled : theme.background,
       borderColor: theme.disabled,
     },
     disabledText: {
-      color: theme.disabled,
+      color: !outlined ? theme.background : theme.textDisabled,
     },
     hovered: {
       shadowColor: 'black',
@@ -163,6 +169,7 @@ const StyledButton: FC<ButtonProps & {theme: DoobooTheme}> = ({
       {loading ? (
         <ButtonContainer
           testID="loading-view"
+          disabled
           style={[
             compositeStyles.container,
             {
@@ -188,6 +195,7 @@ const StyledButton: FC<ButtonProps & {theme: DoobooTheme}> = ({
           onLayout={(e) => setLayout(e.nativeEvent.layout)}
           type={type}
           size={size}
+          disabled={disabled}
           outlined={outlined}>
           {leftElement}
           <TypographyInverted.Heading3

--- a/stories/dooboo-ui/ButtonStories/ButtonDefaultStory.tsx
+++ b/stories/dooboo-ui/ButtonStories/ButtonDefaultStory.tsx
@@ -48,6 +48,7 @@ const ButtonDefault: FC = () => {
           <Button type="danger" text="Danger" style={{padding: 8}} />
           <Button type="warning" text="Warning" style={{padding: 8}} />
           <Button type="info" text="Info" style={{padding: 8}} />
+          <Button disabled={true} text="Disabled" style={{padding: 8}} />
         </View>
         <Hr />
         <Text style={{fontSize: 18, marginTop: 24, marginBottom: 8}}>
@@ -71,6 +72,12 @@ const ButtonDefault: FC = () => {
           <Button type="danger" text="Danger" outlined style={{padding: 8}} />
           <Button type="warning" text="Warning" outlined style={{padding: 8}} />
           <Button type="info" text="Info" outlined style={{padding: 8}} />
+          <Button
+            disabled={true}
+            text="Disabled"
+            outlined
+            style={{padding: 8}}
+          />
         </View>
         <Hr />
         <Text style={{fontSize: 18, marginBottom: 8, marginTop: 16}}>

--- a/stories/dooboo-ui/ButtonStories/index.tsx
+++ b/stories/dooboo-ui/ButtonStories/index.tsx
@@ -1,8 +1,8 @@
 import React, {ReactElement} from 'react';
-import {ThemeProvider, ThemeType} from '../../../main/theme';
 
 import ButtonDefault from './ButtonDefaultStory';
 import {ContainerDeco} from '../../../storybook/decorators';
+import {ThemeProvider} from '../../../main/theme';
 import {storiesOf} from '@storybook/react-native';
 
 /**


### PR DESCRIPTION
## Description

The `disabled` button wasn't styled correctly. Managed to fix this in both styles.

## Tests

Already covered.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
