### PR TITLE
Add [RadioGroup] to main component

### DIFF
--- a/main/RadioGroup/RadioButton.tsx
+++ b/main/RadioGroup/RadioButton.tsx
@@ -28,6 +28,7 @@ export type RadioButtonType =
   | 'info';
 
 export type RadioButtonProps = {
+  testID?: string;
   onPress?: () => void;
   label?: string;
   labelPosition?: 'left' | 'right';
@@ -74,13 +75,14 @@ const StyledRadioCircle = styled(RadioWrapper)<{
 `;
 
 const RadioButtonContainer: FC<RadioButtonProps> = ({
+  testID,
   style,
   styles,
   rightElement,
   leftElement,
   type = 'primary',
   disabled = false,
-  selected: selected = false,
+  selected,
   onPress,
   label,
   labelPosition = 'right',
@@ -89,6 +91,7 @@ const RadioButtonContainer: FC<RadioButtonProps> = ({
 
   return (
     <Container
+      testID={testID}
       disabled={disabled}
       style={style}
       onPress={onPress}
@@ -108,21 +111,21 @@ const RadioButtonContainer: FC<RadioButtonProps> = ({
         {label && labelPosition === 'left' && (
           <ColoredText
             type={type}
-            selected={selected}
+            selected={!!selected}
             disabled={disabled}
             style={styles?.label}>
             {label}
           </ColoredText>
         )}
         <StyledRadioButton
-          testID="doobooui-radiobutton"
           style={styles?.radio}
-          selected={selected}
+          selected={!!selected}
           type={type}
           disabled={disabled}>
           <StyledRadioCircle
+            testID={`circle-${testID}`}
             type={type}
-            selected={selected}
+            selected={!!selected}
             innerLayout={innerLayout}
             onLayout={(e) => setInnerLayout(e.nativeEvent.layout)}
           />

--- a/main/RadioGroup/RadioButton.tsx
+++ b/main/RadioGroup/RadioButton.tsx
@@ -64,6 +64,7 @@ const StyledRadioButton = styled(RadioButtonWrapper)<{
 
 const StyledRadioCircle = styled(RadioWrapper)<{
   selected?: boolean;
+  disabled?: boolean;
   innerLayout?: LayoutRectangle;
 }>`
   flex: 1;
@@ -126,6 +127,7 @@ const RadioButtonContainer: FC<RadioButtonProps> = ({
             testID={`circle-${testID}`}
             type={type}
             selected={!!selected}
+            disabled={!!disabled}
             innerLayout={innerLayout}
             onLayout={(e) => setInnerLayout(e.nativeEvent.layout)}
           />
@@ -133,8 +135,8 @@ const RadioButtonContainer: FC<RadioButtonProps> = ({
         {label && labelPosition === 'right' && (
           <ColoredText
             type={type}
-            selected={selected}
-            disabled={disabled}
+            selected={!!selected}
+            disabled={!!disabled}
             style={styles?.label}>
             {label}
           </ColoredText>

--- a/main/RadioGroup/RadioButton.tsx
+++ b/main/RadioGroup/RadioButton.tsx
@@ -1,0 +1,147 @@
+import {
+  ColoredText,
+  RadioButtonWrapper,
+  RadioWrapper,
+} from '../Styled/StyledComponents';
+import {DoobooTheme, light, withTheme} from '../theme';
+import {
+  LayoutRectangle,
+  StyleProp,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+import React, {FC, useState} from 'react';
+
+import styled from '@emotion/native';
+
+type Styles = {
+  radio?: StyleProp<ViewStyle>;
+  label?: StyleProp<TextStyle>;
+};
+
+export type RadioButtonType =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'warning'
+  | 'info';
+
+export type RadioButtonProps = {
+  onPress?: () => void;
+  label?: string;
+  labelPosition?: 'left' | 'right';
+  style?: StyleProp<ViewStyle>;
+  styles?: Styles;
+  type?: RadioButtonType;
+  disabled?: boolean;
+  theme?: DoobooTheme;
+  selected?: boolean;
+  rightElement?: React.ReactElement;
+  leftElement?: React.ReactElement;
+};
+
+const Container = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+`;
+
+const StyledRadioButton = styled(RadioButtonWrapper)<{
+  selected?: boolean;
+  disabled?: boolean;
+  type?: RadioButtonType;
+}>`
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  border-width: 1px;
+  margin: 0 6px;
+
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledRadioCircle = styled(RadioWrapper)<{
+  selected?: boolean;
+  innerLayout?: LayoutRectangle;
+}>`
+  flex: 1;
+  align-self: stretch;
+
+  margin: ${({innerLayout}) => innerLayout && '2px'};
+  border-radius: ${({innerLayout}) =>
+    innerLayout && `${innerLayout.width / 2}px`};
+`;
+
+const RadioButtonContainer: FC<RadioButtonProps> = ({
+  style,
+  styles,
+  rightElement,
+  leftElement,
+  type = 'primary',
+  disabled = false,
+  selected: selected = false,
+  onPress,
+  label,
+  labelPosition = 'right',
+}) => {
+  const [innerLayout, setInnerLayout] = useState<LayoutRectangle>();
+
+  return (
+    <Container
+      disabled={disabled}
+      style={style}
+      onPress={onPress}
+      activeOpacity={0.9}>
+      <View
+        style={{
+          paddingVertical: 6,
+          paddingLeft:
+            leftElement || (label && labelPosition === 'left') ? 8 : 0,
+          paddingRight:
+            rightElement || (label && labelPosition === 'right') ? 8 : 0,
+
+          flexDirection: 'row',
+          alignItems: 'center',
+        }}>
+        {leftElement}
+        {label && labelPosition === 'left' && (
+          <ColoredText
+            type={type}
+            selected={selected}
+            disabled={disabled}
+            style={styles?.label}>
+            {label}
+          </ColoredText>
+        )}
+        <StyledRadioButton
+          testID="doobooui-radiobutton"
+          style={styles?.radio}
+          selected={selected}
+          type={type}
+          disabled={disabled}>
+          <StyledRadioCircle
+            type={type}
+            selected={selected}
+            innerLayout={innerLayout}
+            onLayout={(e) => setInnerLayout(e.nativeEvent.layout)}
+          />
+        </StyledRadioButton>
+        {label && labelPosition === 'right' && (
+          <ColoredText
+            type={type}
+            selected={selected}
+            disabled={disabled}
+            style={styles?.label}>
+            {label}
+          </ColoredText>
+        )}
+        {rightElement}
+      </View>
+    </Container>
+  );
+};
+
+RadioButtonContainer.defaultProps = {theme: light};
+
+export const RadioButton = withTheme(RadioButtonContainer);

--- a/main/RadioGroup/index.tsx
+++ b/main/RadioGroup/index.tsx
@@ -28,6 +28,7 @@ type Props<T> = {
   styles?: Styles;
   labels?: string[];
   radioType?: Omit<RadioButtonProps, 'type' | 'theme'>;
+  labelPosition?: 'left' | 'right';
 };
 
 const Container = styled.View`
@@ -42,8 +43,17 @@ const Content = styled.View`
 function RadioGroupContainer<T>(
   props: Omit<Props<T>, 'selected'>,
 ): ReactElement {
-  const {title, data, selectedValue, selectValue, style, styles, type, labels} =
-    props;
+  const {
+    title,
+    data,
+    selectedValue,
+    selectValue,
+    style,
+    styles,
+    type,
+    labels,
+    labelPosition,
+  } = props;
 
   return (
     <Container style={style}>
@@ -54,12 +64,14 @@ function RadioGroupContainer<T>(
           return (
             <RadioButtonComp
               key={`radio-${i}`}
+              testID={`radio-${i}`}
               {...props.radioType}
               label={labels?.[i] || ''}
               type={type}
               selected={selectedValue === datum}
               onPress={() => selectValue?.(datum)}
               styles={{label: styles?.label}}
+              labelPosition={labelPosition}
             />
           );
         })}

--- a/main/RadioGroup/index.tsx
+++ b/main/RadioGroup/index.tsx
@@ -1,0 +1,75 @@
+import {DoobooTheme, light} from '../theme';
+import {
+  RadioButton as RadioButtonComp,
+  RadioButtonProps,
+  RadioButtonType,
+} from './RadioButton';
+import React, {ReactElement} from 'react';
+import {StyleProp, TextStyle, View, ViewStyle} from 'react-native';
+
+import {Heading3} from '../Typography/Typography';
+import styled from '@emotion/native';
+
+type Styles = {
+  constainer?: StyleProp<ViewStyle>;
+  title?: StyleProp<TextStyle>;
+  label?: StyleProp<TextStyle>;
+};
+
+type Props<T> = {
+  theme?: DoobooTheme;
+  title?: string;
+  data: T[];
+  selectedValue: T;
+  renderItem?: ({item: T, i: number}) => ReactElement;
+  selectValue?: (item: T) => void;
+  type?: RadioButtonType;
+  style?: StyleProp<ViewStyle>;
+  styles?: Styles;
+  labels?: string[];
+  radioType?: Omit<RadioButtonProps, 'type' | 'theme'>;
+};
+
+const Container = styled.View`
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const Content = styled.View`
+  flex-direction: row;
+`;
+
+function RadioGroupContainer<T>(
+  props: Omit<Props<T>, 'selected'>,
+): ReactElement {
+  const {title, data, selectedValue, selectValue, style, styles, type, labels} =
+    props;
+
+  return (
+    <Container style={style}>
+      <Heading3 style={styles?.title}>{title}</Heading3>
+      {title && <View style={{height: 8}} />}
+      <Content style={styles?.constainer}>
+        {data.map((datum, i) => {
+          return (
+            <RadioButtonComp
+              key={`radio-${i}`}
+              {...props.radioType}
+              label={labels?.[i] || ''}
+              type={type}
+              selected={selectedValue === datum}
+              onPress={() => selectValue?.(datum)}
+              styles={{label: styles?.label}}
+            />
+          );
+        })}
+      </Content>
+    </Container>
+  );
+}
+
+RadioGroupContainer.defaultProps = {theme: light};
+
+export const RadioGroup = RadioGroupContainer;
+
+export const RadioButton = RadioButtonComp;

--- a/main/Styled/StyledComponents.tsx
+++ b/main/Styled/StyledComponents.tsx
@@ -104,3 +104,64 @@ export const CheckboxWrapper = styled.View<{
       ? theme.warning
       : theme.primary};
 `;
+
+export const RadioButtonWrapper = styled.View<{
+  type: ButtonType;
+  disabled?: boolean;
+}>`
+  border-width: 1px;
+  border-color: ${({theme, type, disabled}) =>
+    disabled
+      ? theme.text
+      : type === 'info'
+      ? theme.info
+      : type === 'secondary'
+      ? theme.secondary
+      : type === 'danger'
+      ? theme.danger
+      : type === 'warning'
+      ? theme.warning
+      : theme.primary};
+`;
+
+export const RadioWrapper = styled.View<{
+  type: ButtonType;
+  disabled?: boolean;
+  selected?: boolean;
+}>`
+  background-color: ${({theme, selected, type, disabled}) =>
+    disabled
+      ? undefined
+      : !selected
+      ? theme.background
+      : type === 'info'
+      ? theme.info
+      : type === 'secondary'
+      ? theme.secondary
+      : type === 'danger'
+      ? theme.danger
+      : type === 'warning'
+      ? theme.warning
+      : theme.primary};
+`;
+
+export const ColoredText = styled.Text<{
+  type: ButtonType;
+  disabled?: boolean;
+  selected?: boolean;
+}>`
+  color: ${({theme, selected, type, disabled}) =>
+    disabled
+      ? undefined
+      : !selected
+      ? theme.text
+      : type === 'info'
+      ? theme.info
+      : type === 'secondary'
+      ? theme.secondary
+      : type === 'danger'
+      ? theme.danger
+      : type === 'warning'
+      ? theme.warning
+      : theme.primary};
+`;

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -49,14 +49,13 @@ const AnimatedContainer = styled(Animated.View)`
 
 function Component(props: Props): React.ReactElement {
   const {
-    theme = light,
-    backgroundColorOn = theme.primary,
-    backgroundColorOff = theme.disabled,
-    circleColorOn = theme.textContrast,
-    circleColorOff = theme.placeholder,
     duration = 300,
     backgroundImageOn,
     backgroundImageOff,
+    backgroundColorOn,
+    backgroundColorOff,
+    circleColorOn,
+    circleColorOff,
   } = props;
 
   const [animXValue] = useState(new Animated.Value(props.switchOn ? 1 : 0));
@@ -189,6 +188,11 @@ function Component(props: Props): React.ReactElement {
 }
 
 Component.defaultProps = {
+  theme: light,
+  backgroundColorOn: light.primary,
+  backgroundColorOff: light.disabled,
+  circleColorOn: light.textContrast,
+  circleColorOff: light.placeholder,
   containerStyle: {
     marginTop: 16,
     width: 80,

--- a/main/Typography/Typography.tsx
+++ b/main/Typography/Typography.tsx
@@ -20,7 +20,7 @@ export const Title = withTheme(StyledTitle);
 const StyledHeading1 = styled.Text<{theme: DoobooTheme}>`
   font-size: 22px;
   font-weight: 400;
-  color: ${({theme}) => theme.text || '#000'};
+  color: ${({theme}) => theme.text};
 `;
 
 StyledHeading1.defaultProps = {
@@ -34,7 +34,7 @@ export const Heading1 = withTheme(StyledHeading1);
 const StyledHeading2 = styled.Text<{theme: DoobooTheme}>`
   font-size: 17px;
   font-weight: 400;
-  color: ${({theme}) => theme.text || '#000'};
+  color: ${({theme}) => theme.text};
 `;
 
 StyledHeading2.defaultProps = {
@@ -48,7 +48,7 @@ export const Heading2 = withTheme(StyledHeading2);
 const StyledHeading3 = styled.Text<{theme: DoobooTheme}>`
   font-size: 16px;
   font-weight: 400;
-  color: ${({theme}) => theme.text || '#000'};
+  color: ${({theme}) => theme.text};
 `;
 
 StyledHeading3.defaultProps = {
@@ -61,7 +61,7 @@ export const Heading3 = withTheme(StyledHeading3);
 // Body1
 const StyledBody1 = styled.Text<{theme: DoobooTheme}>`
   font-size: 16px;
-  color: ${({theme}) => theme.text || '#000'};
+  color: ${({theme}) => theme.text};
 `;
 
 StyledBody1.defaultProps = {
@@ -74,7 +74,7 @@ export const Body1 = withTheme(StyledBody1);
 // Body2
 const StyledBody2 = styled.Text<{theme: DoobooTheme}>`
   font-size: 14px;
-  color: ${({theme}) => theme.text || '#000'};
+  color: ${({theme}) => theme.text};
 `;
 
 StyledBody2.defaultProps = {

--- a/main/Typography/TypographyInverted.tsx
+++ b/main/Typography/TypographyInverted.tsx
@@ -20,7 +20,7 @@ export const InvertedTitle = withTheme(InvertedStyledTitle);
 const InvertedStyledHeading1 = styled.Text<{theme: DoobooTheme}>`
   font-size: 22px;
   font-weight: 400;
-  color: ${({theme}) => theme.textContrast || '#fff'};
+  color: ${({theme}) => theme.textContrast};
 `;
 
 InvertedStyledHeading1.defaultProps = {
@@ -34,7 +34,7 @@ export const InvertedHeading1 = withTheme(InvertedStyledHeading1);
 const InvertedStyledHeading2 = styled.Text<{theme: DoobooTheme}>`
   font-size: 17px;
   font-weight: 400;
-  color: ${({theme}) => theme.textContrast || '#fff'};
+  color: ${({theme}) => theme.textContrast};
 `;
 
 InvertedStyledHeading2.defaultProps = {
@@ -48,7 +48,7 @@ export const InvertedHeading2 = withTheme(InvertedStyledHeading2);
 const InvertedStyledHeading3 = styled.Text<{theme: DoobooTheme}>`
   font-size: 16px;
   font-weight: 400;
-  color: ${({theme}) => theme.textContrast || '#000'};
+  color: ${({theme}) => theme.textContrast};
 `;
 
 InvertedStyledHeading3.defaultProps = {
@@ -61,7 +61,7 @@ export const InvertedHeading3 = withTheme(InvertedStyledHeading3);
 // Body1
 const InvertedStyledBody1 = styled.Text<{theme: DoobooTheme}>`
   font-size: 16px;
-  color: ${({theme}) => theme.textContrast || '#000'};
+  color: ${({theme}) => theme.textContrast};
 `;
 
 InvertedStyledBody1.defaultProps = {
@@ -74,7 +74,7 @@ export const InvertedBody1 = withTheme(InvertedStyledBody1);
 // Body2
 const InvertedStyledBody2 = styled.Text<{theme: DoobooTheme}>`
   font-size: 14px;
-  color: ${({theme}) => theme.textContrast || '#000'};
+  color: ${({theme}) => theme.textContrast};
 `;
 
 InvertedStyledBody2.defaultProps = {

--- a/main/__tests__/RadioGroup.test.tsx
+++ b/main/__tests__/RadioGroup.test.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+
+import {RenderAPI, act, fireEvent, render} from '@testing-library/react-native';
+import {Text, View} from 'react-native';
+import {createComponent, createTestProps} from '../../test/testUtils';
+
+import {RadioGroup} from '../RadioGroup';
+
+let props: any;
+let component: React.ReactElement;
+let testingLib: RenderAPI;
+
+const data = ['Person', 'Animal', 'Bird', 'Other'];
+
+describe('[RadioButton] render', () => {
+  it('should render without crashing', () => {
+    props = createTestProps({
+      selectedValue: data[0],
+      selectValue: (value: string) => (props.selectedValue = value),
+    });
+
+    component = createComponent(
+      <View style={{flexDirection: 'row', marginTop: 24}}>
+        <RadioGroup<string>
+          title={'title'}
+          data={data}
+          selectedValue={props.selectedValue}
+          selectValue={props.selectValue}
+        />
+      </View>,
+    );
+
+    testingLib = render(component);
+
+    const json = testingLib.toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+
+  describe('label', () => {
+    it('should render `labels`', () => {
+      props = createTestProps();
+
+      component = createComponent(
+        <View>
+          <View style={{flexDirection: 'row', marginTop: 24}}>
+            <RadioGroup<string>
+              title={'title'}
+              data={data}
+              labels={data}
+              selectedValue={data[0]}
+            />
+          </View>
+        </View>,
+      );
+
+      testingLib = render(component);
+
+      const json = testingLib.toJSON();
+
+      expect(json).toMatchSnapshot();
+    });
+
+    it('should render `labels` with left position', () => {
+      props = createTestProps();
+
+      component = createComponent(
+        <View>
+          <View style={{flexDirection: 'row', marginTop: 24}}>
+            <RadioGroup<string>
+              title={'title'}
+              data={data}
+              labels={data}
+              selectedValue={data[0]}
+              labelPosition="left"
+            />
+          </View>
+        </View>,
+      );
+
+      testingLib = render(component);
+
+      const json = testingLib.toJSON();
+
+      expect(json).toMatchSnapshot();
+    });
+  });
+
+  it('should trigger `selectValue` and change `selectedValue` props', () => {
+    props = createTestProps({
+      selectedValue: data[0],
+      selectValue: (value: string) => (props.selectedValue = value),
+    });
+
+    component = createComponent(
+      <View style={{flexDirection: 'row', marginTop: 24}}>
+        <RadioGroup<string>
+          title={'title'}
+          data={data}
+          selectedValue={props.selectedValue}
+          selectValue={props.selectValue}
+        />
+      </View>,
+    );
+
+    testingLib = render(component);
+
+    const secondOption = testingLib.getByTestId('radio-1');
+
+    expect(props.selectedValue).toEqual(data[0]);
+
+    fireEvent.press(secondOption);
+    expect(props.selectedValue).toEqual(data[1]);
+  });
+});
+
+describe('[RadioButton]', () => {
+  it('should render and trigger `onLayout` and change `innerLayout`', () => {
+    props = createTestProps({
+      selectedValue: data[0],
+      selectValue: (value: string) => (props.selectedValue = value),
+    });
+
+    component = createComponent(
+      <View style={{flexDirection: 'row', marginTop: 24}}>
+        <RadioGroup<string>
+          title={'title'}
+          data={data}
+          selectedValue={props.selectedValue}
+          selectValue={props.selectValue}
+        />
+      </View>,
+    );
+
+    testingLib = render(component);
+
+    const circleRadio = testingLib.getByTestId('circle-radio-0');
+
+    act(() => {
+      circleRadio.props.onLayout({
+        nativeEvent: {
+          layout: {
+            width: 40,
+            height: 40,
+          },
+        },
+      });
+    });
+
+    expect(circleRadio.props.innerLayout).toEqual({
+      width: 40,
+      height: 40,
+    });
+  });
+});

--- a/main/__tests__/RadioGroup.test.tsx
+++ b/main/__tests__/RadioGroup.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {RadioButton, RadioButtonType} from '../RadioGroup/RadioButton';
 import {RenderAPI, act, fireEvent, render} from '@testing-library/react-native';
 import {createComponent, createTestProps} from '../../test/testUtils';
 
@@ -150,6 +151,48 @@ describe('[RadioButton]', () => {
     expect(circleRadio.props.innerLayout).toEqual({
       width: 40,
       height: 40,
+    });
+  });
+
+  describe('colors', () => {
+    const types = ['primary', 'secondary', 'info', 'warning', 'danger'];
+
+    it('should render all colors', () => {
+      component = createComponent(
+        <View>
+          {types.map((el) => {
+            return (
+              <View style={{flexDirection: 'row', marginTop: 24}}>
+                <RadioGroup<string>
+                  title={el}
+                  data={data}
+                  type={el as RadioButtonType}
+                  selectedValue={data[0]}
+                  labels={data}
+                />
+              </View>
+            );
+          })}
+        </View>,
+      );
+
+      testingLib = render(component);
+
+      const json = testingLib.toJSON();
+
+      expect(json).toMatchSnapshot();
+    });
+
+    it('should render `disabled color', () => {
+      component = createComponent(
+        <RadioButton disabled={true} label="label" />,
+      );
+
+      testingLib = render(component);
+
+      const json = testingLib.toJSON();
+
+      expect(json).toMatchSnapshot();
     });
   });
 });

--- a/main/__tests__/RadioGroup.test.tsx
+++ b/main/__tests__/RadioGroup.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import {RenderAPI, act, fireEvent, render} from '@testing-library/react-native';
-import {Text, View} from 'react-native';
 import {createComponent, createTestProps} from '../../test/testUtils';
 
 import {RadioGroup} from '../RadioGroup';
+import {View} from 'react-native';
 
 let props: any;
 let component: React.ReactElement;

--- a/main/__tests__/SwitchToggle.test.tsx
+++ b/main/__tests__/SwitchToggle.test.tsx
@@ -249,11 +249,11 @@ describe('[SwitchToggle]', (): void => {
       expect(props.onPress).toHaveBeenCalled();
     });
 
-    it('should toggle switchOn to `true` on pressed', () => {
+    it('should toggle switch on/off when pressed', () => {
       // eslint-disable-next-line @typescript-eslint/no-shadow
       const props = {
         switchOn: false,
-        onPress: jest.fn(),
+        onPress: () => (props.switchOn = !props.switchOn),
       };
 
       component = <SwitchToggle {...props} />;
@@ -261,13 +261,15 @@ describe('[SwitchToggle]', (): void => {
       const rendered = renderer.create(component);
       const switchToggle = rendered.root.findByType(TouchableOpacity);
 
-      switchToggle.props.onPress();
-
       expect(props.switchOn).toBeFalsy();
 
       switchToggle.props.onPress();
 
-      expect(props.onPress).toHaveBeenCalled();
+      expect(props.switchOn).toBeTruthy();
+
+      switchToggle.props.onPress();
+
+      expect(props.switchOn).toBeFalsy();
     });
 
     it('should toggle switchOn to `false` on pressed', () => {

--- a/main/__tests__/Typography.test.tsx
+++ b/main/__tests__/Typography.test.tsx
@@ -1,0 +1,59 @@
+import {Typography, TypographyInverted} from '../Typography';
+
+import React from 'react';
+import type {ReactElement} from 'react';
+import type {RenderAPI} from '@testing-library/react-native';
+import {ThemeProvider} from '../../main';
+import {View} from 'react-native';
+import {createComponent} from '../../test/testUtils';
+import {render} from '@testing-library/react-native';
+
+let testingLib: RenderAPI;
+
+const Component = (): ReactElement =>
+  createComponent(
+    <View>
+      <Typography.Title />,
+      <Typography.Heading1 />,
+      <Typography.Heading2 />,
+      <Typography.Heading3 />,
+      <Typography.Body1 />,
+      <Typography.Body2 />,
+      <TypographyInverted.Title />
+      <TypographyInverted.Heading1 />
+      <TypographyInverted.Heading2 />
+      <TypographyInverted.Heading3 />
+      <TypographyInverted.Body1 />
+      <TypographyInverted.Body2 />
+    </View>,
+  );
+
+describe('[Typography]', () => {
+  it('should render without crashing', () => {
+    testingLib = render(<Component />);
+
+    const json = testingLib.toJSON();
+
+    expect(json).toBeTruthy();
+  });
+
+  it('should render default theme', () => {
+    testingLib = render(Component());
+
+    const json = testingLib.toJSON();
+
+    expect(json).toBeTruthy();
+  });
+
+  it('should render [dark] mode', () => {
+    testingLib = render(
+      <ThemeProvider initialThemeType="dark">
+        <Component />
+      </ThemeProvider>,
+    );
+
+    const json = testingLib.toJSON();
+
+    expect(json).toBeTruthy();
+  });
+});

--- a/main/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/main/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,5 +1,2614 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`[RadioButton] colors should render \`disabled color 1`] = `
+<View
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "paddingLeft": 0,
+        "paddingRight": 8,
+        "paddingVertical": 6,
+      }
+    }
+  >
+    <View
+      disabled={true}
+      selected={false}
+      style={
+        Array [
+          Object {
+            "borderBottomColor": "black",
+            "borderBottomWidth": 1,
+            "borderLeftColor": "black",
+            "borderLeftWidth": 1,
+            "borderRightColor": "black",
+            "borderRightWidth": 1,
+            "borderTopColor": "black",
+            "borderTopWidth": 1,
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "borderBottomLeftRadius": 10,
+              "borderBottomRightRadius": 10,
+              "borderBottomWidth": 1,
+              "borderLeftWidth": 1,
+              "borderRightWidth": 1,
+              "borderTopLeftRadius": 10,
+              "borderTopRightRadius": 10,
+              "borderTopWidth": 1,
+              "height": 20,
+              "justifyContent": "center",
+              "marginBottom": 0,
+              "marginLeft": 6,
+              "marginRight": 6,
+              "marginTop": 0,
+              "width": 20,
+            },
+            undefined,
+          ],
+        ]
+      }
+      type="primary"
+    >
+      <View
+        disabled={true}
+        onLayout={[Function]}
+        selected={false}
+        style={
+          Array [
+            Object {},
+            Array [
+              Object {
+                "alignSelf": "stretch",
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              undefined,
+            ],
+          ]
+        }
+        testID="circle-undefined"
+        type="primary"
+      />
+    </View>
+    <Text
+      disabled={true}
+      selected={false}
+      style={
+        Array [
+          Object {},
+          undefined,
+        ]
+      }
+      type="primary"
+    >
+      label
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`[RadioButton] colors should render all colors 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        primary
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "black",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        secondary
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#00D9D5",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#00D9D5",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#00D9D5",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#00D9D5",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="secondary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#00D9D5",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="secondary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "#00D9D5",
+                  },
+                  undefined,
+                ]
+              }
+              type="secondary"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#00D9D5",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#00D9D5",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#00D9D5",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#00D9D5",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="secondary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="secondary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="secondary"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#00D9D5",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#00D9D5",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#00D9D5",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#00D9D5",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="secondary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="secondary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="secondary"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#00D9D5",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#00D9D5",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#00D9D5",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#00D9D5",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="secondary"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="secondary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="secondary"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        info
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#5398FF",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#5398FF",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#5398FF",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#5398FF",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="info"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#5398FF",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="info"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "#5398FF",
+                  },
+                  undefined,
+                ]
+              }
+              type="info"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#5398FF",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#5398FF",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#5398FF",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#5398FF",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="info"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="info"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="info"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#5398FF",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#5398FF",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#5398FF",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#5398FF",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="info"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="info"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="info"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#5398FF",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#5398FF",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#5398FF",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#5398FF",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="info"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="info"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="info"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        warning
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FFEB14",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FFEB14",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FFEB14",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FFEB14",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="warning"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#FFEB14",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="warning"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "#FFEB14",
+                  },
+                  undefined,
+                ]
+              }
+              type="warning"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FFEB14",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FFEB14",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FFEB14",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FFEB14",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="warning"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="warning"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="warning"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FFEB14",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FFEB14",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FFEB14",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FFEB14",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="warning"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="warning"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="warning"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FFEB14",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FFEB14",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FFEB14",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FFEB14",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="warning"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="warning"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="warning"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        danger
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FF002E",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FF002E",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FF002E",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FF002E",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="danger"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#FF002E",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="danger"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "#FF002E",
+                  },
+                  undefined,
+                ]
+              }
+              type="danger"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FF002E",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FF002E",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FF002E",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FF002E",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="danger"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="danger"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="danger"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FF002E",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FF002E",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FF002E",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FF002E",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="danger"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="danger"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="danger"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#FF002E",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "#FF002E",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "#FF002E",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "#FF002E",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="danger"
+            >
+              <View
+                disabled={false}
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="danger"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="danger"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`[RadioButton] render label should render \`labels\` 1`] = `
 <View>
   <View
@@ -125,6 +2734,7 @@ exports[`[RadioButton] render label should render \`labels\` 1`] = `
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={true}
                 style={
@@ -235,6 +2845,7 @@ exports[`[RadioButton] render label should render \`labels\` 1`] = `
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -345,6 +2956,7 @@ exports[`[RadioButton] render label should render \`labels\` 1`] = `
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -455,6 +3067,7 @@ exports[`[RadioButton] render label should render \`labels\` 1`] = `
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -640,6 +3253,7 @@ exports[`[RadioButton] render label should render \`labels\` with left position 
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={true}
                 style={
@@ -750,6 +3364,7 @@ exports[`[RadioButton] render label should render \`labels\` with left position 
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -860,6 +3475,7 @@ exports[`[RadioButton] render label should render \`labels\` with left position 
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -970,6 +3586,7 @@ exports[`[RadioButton] render label should render \`labels\` with left position 
               type="primary"
             >
               <View
+                disabled={false}
                 onLayout={[Function]}
                 selected={false}
                 style={
@@ -1125,6 +3742,7 @@ exports[`[RadioButton] render should render without crashing 1`] = `
             type="primary"
           >
             <View
+              disabled={false}
               onLayout={[Function]}
               selected={true}
               style={
@@ -1222,6 +3840,7 @@ exports[`[RadioButton] render should render without crashing 1`] = `
             type="primary"
           >
             <View
+              disabled={false}
               onLayout={[Function]}
               selected={false}
               style={
@@ -1319,6 +3938,7 @@ exports[`[RadioButton] render should render without crashing 1`] = `
             type="primary"
           >
             <View
+              disabled={false}
               onLayout={[Function]}
               selected={false}
               style={
@@ -1416,6 +4036,7 @@ exports[`[RadioButton] render should render without crashing 1`] = `
             type="primary"
           >
             <View
+              disabled={false}
               onLayout={[Function]}
               selected={false}
               style={

--- a/main/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/main/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,0 +1,1447 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[RadioButton] render label should render \`labels\` 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        title
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "black",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Person
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Animal
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Bird
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 0,
+                "paddingRight": 8,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="primary"
+              />
+            </View>
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Other
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`[RadioButton] render label should render \`labels\` with left position 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginTop": 24,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "fontWeight": "400",
+            },
+            Object {
+              "includeFontPadding": false,
+            },
+          ]
+        }
+      >
+        title
+      </Text>
+      <View
+        style={
+          Object {
+            "height": 8,
+          }
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-0"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 8,
+                "paddingRight": 0,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <Text
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Person
+            </Text>
+            <View
+              disabled={false}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={true}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "black",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-0"
+                type="primary"
+              />
+            </View>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-1"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 8,
+                "paddingRight": 0,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Animal
+            </Text>
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-1"
+                type="primary"
+              />
+            </View>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-2"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 8,
+                "paddingRight": 0,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Bird
+            </Text>
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-2"
+                type="primary"
+              />
+            </View>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "opacity": 1,
+            }
+          }
+          testID="radio-3"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingLeft": 8,
+                "paddingRight": 0,
+                "paddingVertical": 6,
+              }
+            }
+          >
+            <Text
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                  },
+                  undefined,
+                ]
+              }
+              type="primary"
+            >
+              Other
+            </Text>
+            <View
+              disabled={false}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "black",
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "black",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "black",
+                    "borderRightWidth": 1,
+                    "borderTopColor": "black",
+                    "borderTopWidth": 1,
+                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "borderBottomLeftRadius": 10,
+                      "borderBottomRightRadius": 10,
+                      "borderBottomWidth": 1,
+                      "borderLeftWidth": 1,
+                      "borderRightWidth": 1,
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "borderTopWidth": 1,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                      "marginLeft": 6,
+                      "marginRight": 6,
+                      "marginTop": 0,
+                      "width": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              type="primary"
+            >
+              <View
+                onLayout={[Function]}
+                selected={false}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    Array [
+                      Object {
+                        "alignSelf": "stretch",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="circle-radio-3"
+                type="primary"
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`[RadioButton] render should render without crashing 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "marginTop": 24,
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "flexDirection": "column",
+          "justifyContent": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "black",
+            "fontSize": 16,
+            "fontWeight": "400",
+          },
+          Object {
+            "includeFontPadding": false,
+          },
+        ]
+      }
+    >
+      title
+    </Text>
+    <View
+      style={
+        Object {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexDirection": "row",
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "opacity": 1,
+          }
+        }
+        testID="radio-0"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingVertical": 6,
+            }
+          }
+        >
+          
+          <View
+            disabled={false}
+            selected={true}
+            style={
+              Array [
+                Object {
+                  "borderBottomColor": "black",
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "black",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "black",
+                  "borderRightWidth": 1,
+                  "borderTopColor": "black",
+                  "borderTopWidth": 1,
+                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomLeftRadius": 10,
+                    "borderBottomRightRadius": 10,
+                    "borderBottomWidth": 1,
+                    "borderLeftWidth": 1,
+                    "borderRightWidth": 1,
+                    "borderTopLeftRadius": 10,
+                    "borderTopRightRadius": 10,
+                    "borderTopWidth": 1,
+                    "height": 20,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                    "marginLeft": 6,
+                    "marginRight": 6,
+                    "marginTop": 0,
+                    "width": 20,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            type="primary"
+          >
+            <View
+              onLayout={[Function]}
+              selected={true}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "black",
+                  },
+                  Array [
+                    Object {
+                      "alignSelf": "stretch",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              testID="circle-radio-0"
+              type="primary"
+            />
+          </View>
+          
+        </View>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "opacity": 1,
+          }
+        }
+        testID="radio-1"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingVertical": 6,
+            }
+          }
+        >
+          
+          <View
+            disabled={false}
+            selected={false}
+            style={
+              Array [
+                Object {
+                  "borderBottomColor": "black",
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "black",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "black",
+                  "borderRightWidth": 1,
+                  "borderTopColor": "black",
+                  "borderTopWidth": 1,
+                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomLeftRadius": 10,
+                    "borderBottomRightRadius": 10,
+                    "borderBottomWidth": 1,
+                    "borderLeftWidth": 1,
+                    "borderRightWidth": 1,
+                    "borderTopLeftRadius": 10,
+                    "borderTopRightRadius": 10,
+                    "borderTopWidth": 1,
+                    "height": 20,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                    "marginLeft": 6,
+                    "marginRight": 6,
+                    "marginTop": 0,
+                    "width": 20,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            type="primary"
+          >
+            <View
+              onLayout={[Function]}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  Array [
+                    Object {
+                      "alignSelf": "stretch",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              testID="circle-radio-1"
+              type="primary"
+            />
+          </View>
+          
+        </View>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "opacity": 1,
+          }
+        }
+        testID="radio-2"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingVertical": 6,
+            }
+          }
+        >
+          
+          <View
+            disabled={false}
+            selected={false}
+            style={
+              Array [
+                Object {
+                  "borderBottomColor": "black",
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "black",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "black",
+                  "borderRightWidth": 1,
+                  "borderTopColor": "black",
+                  "borderTopWidth": 1,
+                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomLeftRadius": 10,
+                    "borderBottomRightRadius": 10,
+                    "borderBottomWidth": 1,
+                    "borderLeftWidth": 1,
+                    "borderRightWidth": 1,
+                    "borderTopLeftRadius": 10,
+                    "borderTopRightRadius": 10,
+                    "borderTopWidth": 1,
+                    "height": 20,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                    "marginLeft": 6,
+                    "marginRight": 6,
+                    "marginTop": 0,
+                    "width": 20,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            type="primary"
+          >
+            <View
+              onLayout={[Function]}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  Array [
+                    Object {
+                      "alignSelf": "stretch",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              testID="circle-radio-2"
+              type="primary"
+            />
+          </View>
+          
+        </View>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "opacity": 1,
+          }
+        }
+        testID="radio-3"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingVertical": 6,
+            }
+          }
+        >
+          
+          <View
+            disabled={false}
+            selected={false}
+            style={
+              Array [
+                Object {
+                  "borderBottomColor": "black",
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "black",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "black",
+                  "borderRightWidth": 1,
+                  "borderTopColor": "black",
+                  "borderTopWidth": 1,
+                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomLeftRadius": 10,
+                    "borderBottomRightRadius": 10,
+                    "borderBottomWidth": 1,
+                    "borderLeftWidth": 1,
+                    "borderRightWidth": 1,
+                    "borderTopLeftRadius": 10,
+                    "borderTopRightRadius": 10,
+                    "borderTopWidth": 1,
+                    "height": 20,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                    "marginLeft": 6,
+                    "marginRight": 6,
+                    "marginTop": 0,
+                    "width": 20,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            type="primary"
+          >
+            <View
+              onLayout={[Function]}
+              selected={false}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  Array [
+                    Object {
+                      "alignSelf": "stretch",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              testID="circle-radio-3"
+              type="primary"
+            />
+          </View>
+          
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
+++ b/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityHint 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -38,7 +38,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityHint 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -89,7 +89,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityLabel 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -105,7 +105,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityLabel 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -156,7 +156,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityRole 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -172,7 +172,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityRole 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -223,7 +223,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityState 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -239,7 +239,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityState 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -290,7 +290,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityValue 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -306,7 +306,7 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityValue 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -357,7 +357,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleW
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "flexDirection": "row",
         "padding": 40,
         "width": 40,
@@ -370,7 +370,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleW
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 80,
@@ -421,7 +421,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleW
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "flexDirection": "row",
         "padding": 0,
         "width": 40,
@@ -434,7 +434,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleW
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": "NaN[object Object]",
@@ -485,7 +485,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`contain
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "flexDirection": "row",
         "padding": 40,
       }
@@ -497,7 +497,7 @@ exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`contain
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "borderRadius": 16,
           "height": 32,
           "transform": Array [
@@ -550,7 +550,7 @@ exports[`[SwitchToggle] Rendering should render RTL 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -566,7 +566,7 @@ exports[`[SwitchToggle] Rendering should render RTL 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -617,7 +617,7 @@ exports[`[SwitchToggle] Rendering should render type === 0 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -633,7 +633,7 @@ exports[`[SwitchToggle] Rendering should render type === 0 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "borderRadius": 16,
           "height": 32,
           "transform": Array [
@@ -686,7 +686,7 @@ exports[`[SwitchToggle] Rendering should render when \`containerStyle\` is not d
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -702,7 +702,7 @@ exports[`[SwitchToggle] Rendering should render when \`containerStyle\` is not d
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "transform": Array [
             Object {
               "translateX": 10,
@@ -753,7 +753,7 @@ exports[`[SwitchToggle] Rendering should render without crashing 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(196, 196, 196, 1)",
         "borderRadius": 25,
         "flexDirection": "row",
         "height": 40,
@@ -769,7 +769,7 @@ exports[`[SwitchToggle] Rendering should render without crashing 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "rgba(-37, -37, -37, 1)",
           "borderRadius": 16,
           "height": 32,
           "transform": Array [

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,4 +1,5 @@
 export * from './Typography';
+export * from './RadioGroup';
 export * from './Icon';
 export * from './Hr';
 export * from './Button';

--- a/stories/dooboo-ui/ButtonStories/ButtonDefaultStory.tsx
+++ b/stories/dooboo-ui/ButtonStories/ButtonDefaultStory.tsx
@@ -1,6 +1,6 @@
 import {Button, Hr} from '../../../main';
 import {IC_FACEBOOK, IC_GOOGLE} from '../../Icon';
-import {Image, Text, View} from 'react-native';
+import {Image, View} from 'react-native';
 import React, {useState} from 'react';
 import styled, {css} from '@emotion/native';
 
@@ -13,18 +13,13 @@ const StoryContainer = styled.View`
   background-color: ${({theme}) => theme.background};
 `;
 
-const ScrollContainer = styled.ScrollView`
-  width: 100%;
+const StyledText = styled.Text`
+  margin: 8px;
+  color: ${({theme}) => theme.text};
 `;
 
-const Container = styled.View`
-  background-color: ${({theme}) => theme.background};
-  align-items: center;
-  justify-content: center;
+const ScrollContainer = styled.ScrollView`
   width: 100%;
-  margin-top: 20px;
-  margin-bottom: 20px;
-  flex-direction: column;
 `;
 
 const ButtonDefault: FC = () => {
@@ -33,160 +28,156 @@ const ButtonDefault: FC = () => {
 
   return (
     <StoryContainer>
-      <ScrollContainer>
-        <Container style={{paddingVertical: 60}}>
-          <Text style={{fontSize: 18, marginBottom: 8}}>Basic Styles</Text>
-          <View
-            style={{
-              marginBottom: 40,
+      <ScrollContainer
+        contentContainerStyle={{
+          paddingVertical: 60,
+          paddingHorizontal: 40,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <StyledText style={{fontSize: 18, marginBottom: 8}}>
+          Basic Styles
+        </StyledText>
+        <View
+          style={{
+            marginBottom: 40,
 
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-            }}>
-            <Button type="primary" text="Primary" style={{padding: 8}} />
-            <Button type="secondary" text="Secondary" style={{padding: 8}} />
-            <Button type="danger" text="Danger" style={{padding: 8}} />
-            <Button type="warning" text="Warning" style={{padding: 8}} />
-            <Button type="info" text="Info" style={{padding: 8}} />
-            <Button disabled={true} text="Disabled" style={{padding: 8}} />
-          </View>
-          <Hr />
-          <Text style={{fontSize: 18, marginTop: 24, marginBottom: 8}}>
-            Outlined Styles
-          </Text>
-          <View
-            style={{
-              marginBottom: 40,
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+          }}>
+          <Button type="primary" text="Primary" style={{padding: 8}} />
+          <Button type="secondary" text="Secondary" style={{padding: 8}} />
+          <Button type="danger" text="Danger" style={{padding: 8}} />
+          <Button type="warning" text="Warning" style={{padding: 8}} />
+          <Button type="info" text="Info" style={{padding: 8}} />
+          <Button disabled={true} text="Disabled" style={{padding: 8}} />
+        </View>
+        <Hr />
+        <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 8}}>
+          Outlined Styles
+        </StyledText>
+        <View
+          style={{
+            marginBottom: 40,
 
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-            }}>
-            <Button
-              type="primary"
-              text="Primary"
-              outlined
-              style={{padding: 8}}
-            />
-            <Button
-              type="secondary"
-              text="Secondary"
-              outlined
-              style={{padding: 8}}
-            />
-            <Button type="danger" text="Danger" outlined style={{padding: 8}} />
-            <Button
-              type="warning"
-              text="Warning"
-              outlined
-              style={{padding: 8}}
-            />
-            <Button type="info" text="Info" outlined style={{padding: 8}} />
-            <Button
-              disabled={true}
-              text="Disabled"
-              outlined
-              style={{padding: 8}}
-            />
-          </View>
-          <Hr />
-          <Text style={{fontSize: 18, marginBottom: 8, marginTop: 16}}>
-            Aspect of sizes
-          </Text>
-          <View
-            style={{
-              marginBottom: 20,
-
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <Button
-              type="primary"
-              size="large"
-              text="Primary"
-              style={{padding: 8}}
-            />
-            <Button
-              type="primary"
-              size="medium"
-              text="Primary"
-              style={{padding: 8}}
-            />
-            <Button
-              type="primary"
-              size="small"
-              text="Primary"
-              style={{padding: 8}}
-            />
-          </View>
-          <Hr />
-          <Text style={{fontSize: 18, marginTop: 16, marginBottom: 8}}>
-            Adding elements
-          </Text>
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+          }}>
+          <Button type="primary" text="Primary" outlined style={{padding: 8}} />
           <Button
-            leftElement={
-              <View style={{marginRight: 12}}>
-                <Image style={{width: 20, height: 20}} source={IC_GOOGLE} />
-              </View>
-            }
+            type="secondary"
+            text="Secondary"
             outlined
-            loading={googleLoading}
-            style={{marginBottom: 20, marginTop: 30}}
-            styles={{
-              container: css`
-                border-radius: 80px;
-                border-width: 0.5px;
-                width: 300px;
-                height: 52px;
-              `,
-            }}
-            onPress={(): void => {
-              setGoogleLoading(true);
-              action('google btn clicked');
+            style={{padding: 8}}
+          />
+          <Button type="danger" text="Danger" outlined style={{padding: 8}} />
+          <Button type="warning" text="Warning" outlined style={{padding: 8}} />
+          <Button type="info" text="Info" outlined style={{padding: 8}} />
+          <Button
+            disabled={true}
+            text="Disabled"
+            outlined
+            style={{padding: 8}}
+          />
+        </View>
+        <Hr />
+        <StyledText style={{fontSize: 18, marginBottom: 8, marginTop: 16}}>
+          Aspect of sizes
+        </StyledText>
+        <View
+          style={{
+            marginBottom: 20,
 
-              const timeout = setTimeout(() => {
-                setGoogleLoading(false);
-                clearTimeout(timeout);
-              }, 2000);
-            }}
-            text="GOOGLE SIGN IN"
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+          <Button
+            type="primary"
+            size="large"
+            text="Primary"
+            style={{padding: 8}}
           />
           <Button
-            testID="btnFacebook"
-            outlined
-            leftElement={
-              <View
-                style={{
-                  position: 'absolute',
-                  left: 28,
-                }}>
-                <Image style={{width: 15, height: 28}} source={IC_FACEBOOK} />
-              </View>
-            }
-            loading={facebookLoading}
-            styles={{
-              container: css`
-                border-radius: 80px;
-                border-width: 0.5px;
-                width: 300px;
-                height: 52px;
-              `,
-            }}
-            onPress={(): void => {
-              setFacebookLoading(true);
-              action('facebook btn clicked');
-
-              const timeout = setTimeout(() => {
-                setFacebookLoading(false);
-                clearTimeout(timeout);
-              }, 2000);
-            }}
-            text="FACEBOOK SIGN IN"
+            type="primary"
+            size="medium"
+            text="Primary"
+            style={{padding: 8}}
           />
-        </Container>
+          <Button
+            type="primary"
+            size="small"
+            text="Primary"
+            style={{padding: 8}}
+          />
+        </View>
+        <Hr />
+        <StyledText style={{fontSize: 18, marginTop: 16, marginBottom: 8}}>
+          Adding elements
+        </StyledText>
+        <Button
+          leftElement={
+            <View style={{marginRight: 12}}>
+              <Image style={{width: 20, height: 20}} source={IC_GOOGLE} />
+            </View>
+          }
+          outlined
+          loading={googleLoading}
+          style={{marginBottom: 20, marginTop: 30}}
+          styles={{
+            container: css`
+              border-radius: 80px;
+              border-width: 0.5px;
+              width: 300px;
+              height: 52px;
+            `,
+          }}
+          onPress={(): void => {
+            setGoogleLoading(true);
+            action('google btn clicked');
+
+            const timeout = setTimeout(() => {
+              setGoogleLoading(false);
+              clearTimeout(timeout);
+            }, 2000);
+          }}
+          text="GOOGLE SIGN IN"
+        />
+        <Button
+          testID="btnFacebook"
+          outlined
+          leftElement={
+            <View
+              style={{
+                position: 'absolute',
+                left: 28,
+              }}>
+              <Image style={{width: 15, height: 28}} source={IC_FACEBOOK} />
+            </View>
+          }
+          loading={facebookLoading}
+          styles={{
+            container: css`
+              border-radius: 80px;
+              border-width: 0.5px;
+              width: 300px;
+              height: 52px;
+            `,
+          }}
+          onPress={(): void => {
+            setFacebookLoading(true);
+            action('facebook btn clicked');
+
+            const timeout = setTimeout(() => {
+              setFacebookLoading(false);
+              clearTimeout(timeout);
+            }, 2000);
+          }}
+          text="FACEBOOK SIGN IN"
+        />
       </ScrollContainer>
     </StoryContainer>
   );

--- a/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
+++ b/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
@@ -1,27 +1,12 @@
 import {Checkbox, Hr, useTheme} from '../../../main';
 import {FC, useState} from 'react';
-import {Platform, View} from 'react-native';
 
+import {View} from 'react-native';
 import styled from '@emotion/native';
 import {useFonts} from 'expo-font';
 
 const ScrollContainer = styled.ScrollView`
   width: 100%;
-`;
-
-const Container = styled.View`
-  flex: 1;
-  align-self: stretch;
-  flex-wrap: wrap;
-  background-color: ${({theme}) => theme.background};
-  width: 100%;
-  margin-top: 60px;
-  margin-bottom: 40px;
-  padding: 0 16px;
-
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
 `;
 
 const StyledText = styled.Text`
@@ -47,91 +32,89 @@ const CheckboxStory: FC = () => {
       }}>
       <ScrollContainer
         contentContainerStyle={{
-          alignSelf: 'stretch',
-          height: Platform.select({
-            web: '100%',
-          }),
+          paddingVertical: 60,
+          paddingHorizontal: 40,
+          justifyContent: 'center',
+          alignItems: 'center',
         }}>
-        <Container>
-          <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
-            Checkbox
-          </StyledText>
-          <View style={{flexDirection: 'row'}}>
-            <Checkbox checked={checked} onPress={() => setChecked(!checked)} />
-            <View style={{width: 8}} />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              type="secondary"
-            />
-            <View style={{width: 8}} />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              type="warning"
-            />
-            <View style={{width: 8}} />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              type="info"
-            />
-            <View style={{width: 8}} />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              type="danger"
-            />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              disabled
-            />
-          </View>
-          <Hr style={{marginTop: 40}} />
-          <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
-            Checkbox with left element
-          </StyledText>
-          <View style={{flexDirection: 'column'}}>
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              rightElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              rightElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              rightElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-          </View>
-          <Hr style={{marginTop: 40}} />
-          <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
-            Checkbox with right element
-          </StyledText>
-          <View style={{flexDirection: 'column'}}>
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              leftElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              leftElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              leftElement={<StyledText>Hello this is a checkbox</StyledText>}
-            />
-          </View>
-          <View style={{height: 60}} />
-        </Container>
+        <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
+          Checkbox
+        </StyledText>
+        <View style={{flexDirection: 'row'}}>
+          <Checkbox checked={checked} onPress={() => setChecked(!checked)} />
+          <View style={{width: 8}} />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            type="secondary"
+          />
+          <View style={{width: 8}} />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            type="warning"
+          />
+          <View style={{width: 8}} />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            type="info"
+          />
+          <View style={{width: 8}} />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            type="danger"
+          />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            disabled
+          />
+        </View>
+        <Hr style={{marginTop: 40}} />
+        <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
+          Checkbox with right element
+        </StyledText>
+        <View style={{flexDirection: 'column'}}>
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            rightElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            rightElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            rightElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+        </View>
+        <Hr style={{marginTop: 40}} />
+        <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
+          Checkbox withs left element
+        </StyledText>
+        <View style={{flexDirection: 'column'}}>
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            leftElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            leftElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            leftElement={<StyledText>Hello this is a checkbox</StyledText>}
+          />
+        </View>
+        <View style={{height: 60}} />
       </ScrollContainer>
     </View>
   );

--- a/stories/dooboo-ui/IconButtonStories/IconButtonStory.tsx
+++ b/stories/dooboo-ui/IconButtonStories/IconButtonStory.tsx
@@ -1,5 +1,5 @@
 import {Hr, IconButton, useTheme} from '../../../main';
-import {Platform, Text, View} from 'react-native';
+import {Text, View} from 'react-native';
 
 import type {FC} from 'react';
 import {Icon} from '../../../main/Icon';
@@ -14,21 +14,6 @@ const StoryContainer = styled.View`
 
 const ScrollContainer = styled.ScrollView`
   width: 100%;
-`;
-
-const Container = styled.View`
-  flex: 1;
-  align-self: stretch;
-  flex-wrap: wrap;
-  background-color: ${({theme}) => theme.background};
-  width: 100%;
-  margin-top: 60px;
-  margin-bottom: 40px;
-  padding: 0 16px;
-
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
 `;
 
 const StyledIcon = styled(Icon)`
@@ -49,96 +34,94 @@ const IconButtonStory: FC = () => {
       <ScrollContainer
         style={{flex: 1}}
         contentContainerStyle={{
-          alignSelf: 'stretch',
-          height: Platform.select({
-            web: '100%',
-          }),
+          paddingVertical: 60,
+          paddingHorizontal: 40,
+          justifyContent: 'center',
+          alignItems: 'center',
         }}>
-        <Container>
-          <Text
-            style={{
-              fontSize: 18,
-              marginTop: 24,
-              marginBottom: 8,
-              color: theme.text,
-            }}>
-            Medium IconButton (default)
-          </Text>
-          <View
-            style={{
-              width: '100%',
-              marginTop: 40,
+        <Text
+          style={{
+            fontSize: 18,
+            marginTop: 24,
+            marginBottom: 8,
+            color: theme.text,
+          }}>
+          Medium IconButton (default)
+        </Text>
+        <View
+          style={{
+            width: '100%',
+            marginTop: 40,
 
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <IconButton icon={<StyledIcon size={24} name="moment-solid" />} />
-            <View style={{width: 8}} />
-            <IconButton icon={<StyledIcon size={24} name="add-light" />} />
-            <View style={{width: 8}} />
-            <IconButton icon={<StyledIcon size={24} name="chevron-right" />} />
-          </View>
-          <Hr style={{marginTop: 40}} />
-          <Text
-            style={{
-              fontSize: 18,
-              marginTop: 24,
-              marginBottom: 8,
-              color: theme.text,
-            }}>
-            Large IconButton
-          </Text>
-          <View
-            style={{
-              marginTop: 40,
-              width: '100%',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+          <IconButton icon={<StyledIcon size={24} name="moment-solid" />} />
+          <View style={{width: 8}} />
+          <IconButton icon={<StyledIcon size={24} name="add-light" />} />
+          <View style={{width: 8}} />
+          <IconButton icon={<StyledIcon size={24} name="chevron-right" />} />
+        </View>
+        <Hr style={{marginTop: 40}} />
+        <Text
+          style={{
+            fontSize: 18,
+            marginTop: 24,
+            marginBottom: 8,
+            color: theme.text,
+          }}>
+          Large IconButton
+        </Text>
+        <View
+          style={{
+            marginTop: 40,
+            width: '100%',
 
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <IconButton
-              size="large"
-              icon={<StyledIcon size={32} name="cross-light" />}
-            />
-            <View style={{width: 8}} />
-            <IconButton
-              size="large"
-              icon={<StyledIcon size={32} name="tile-light" />}
-            />
-          </View>
-          <Hr style={{marginTop: 40}} />
-          <Text
-            style={{
-              fontSize: 18,
-              marginTop: 24,
-              marginBottom: 8,
-              color: theme.text,
-            }}>
-            Small IconButton
-          </Text>
-          <View
-            style={{
-              marginTop: 40,
-              marginBottom: 100,
-              width: '100%',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+          <IconButton
+            size="large"
+            icon={<StyledIcon size={32} name="cross-light" />}
+          />
+          <View style={{width: 8}} />
+          <IconButton
+            size="large"
+            icon={<StyledIcon size={32} name="tile-light" />}
+          />
+        </View>
+        <Hr style={{marginTop: 40}} />
+        <Text
+          style={{
+            fontSize: 18,
+            marginTop: 24,
+            marginBottom: 8,
+            color: theme.text,
+          }}>
+          Small IconButton
+        </Text>
+        <View
+          style={{
+            marginTop: 40,
+            marginBottom: 100,
+            width: '100%',
 
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <IconButton
-              size="small"
-              icon={<StyledIcon size={16} name="cross-light" />}
-            />
-            <View style={{width: 8}} />
-            <IconButton
-              size="small"
-              icon={<StyledIcon size={16} name="tile-light" />}
-            />
-          </View>
-        </Container>
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+          <IconButton
+            size="small"
+            icon={<StyledIcon size={16} name="cross-light" />}
+          />
+          <View style={{width: 8}} />
+          <IconButton
+            size="small"
+            icon={<StyledIcon size={16} name="tile-light" />}
+          />
+        </View>
       </ScrollContainer>
     </StoryContainer>
   );

--- a/stories/dooboo-ui/RadioGroupStories/RadioGroupStory.tsx
+++ b/stories/dooboo-ui/RadioGroupStories/RadioGroupStory.tsx
@@ -1,0 +1,74 @@
+import {FC, useState} from 'react';
+import {RadioGroup, useTheme} from '../../../main';
+
+import {RadioButtonType} from '../../../main/RadioGroup/RadioButton';
+import {View} from 'react-native';
+import styled from '@emotion/native';
+
+const ScrollContainer = styled.ScrollView`
+  width: 100%;
+`;
+
+const StyledText = styled.Text`
+  color: ${({theme}) => theme.text};
+`;
+
+const types = ['primary', 'secondary', 'info', 'warning', 'danger'];
+const data = ['Person', 'Animal', 'Bird', 'Other'];
+
+const RadioButtonStory: FC = () => {
+  const {theme} = useTheme();
+  const [selectedValue, setSelectedValue] = useState<string>(data[0]);
+
+  return (
+    <View
+      style={{
+        backgroundColor: theme.background,
+        flex: 1,
+        alignSelf: 'stretch',
+      }}>
+      <ScrollContainer
+        contentContainerStyle={{
+          alignSelf: 'stretch',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
+          Radio Group
+        </StyledText>
+        {types.map((el) => {
+          return (
+            <View style={{flexDirection: 'row', marginTop: 24}}>
+              <RadioGroup<string>
+                title={el}
+                data={data}
+                type={el as RadioButtonType}
+                selectedValue={selectedValue}
+                selectValue={(value) => setSelectedValue(value)}
+              />
+            </View>
+          );
+        })}
+        <StyledText style={{fontSize: 18, marginTop: 60, marginBottom: 12}}>
+          With elements
+        </StyledText>
+        {types.map((el) => {
+          return (
+            <View style={{flexDirection: 'row', marginTop: 24}}>
+              <RadioGroup<string>
+                title={el}
+                data={data}
+                type={el as RadioButtonType}
+                selectedValue={selectedValue}
+                selectValue={(value) => setSelectedValue(value)}
+                labels={data}
+              />
+            </View>
+          );
+        })}
+      </ScrollContainer>
+    </View>
+  );
+};
+
+export default RadioButtonStory;

--- a/stories/dooboo-ui/RadioGroupStories/index.tsx
+++ b/stories/dooboo-ui/RadioGroupStories/index.tsx
@@ -1,0 +1,35 @@
+import React, {ReactElement} from 'react';
+
+import {ContainerDeco} from '../../../storybook/decorators';
+import RadioGroupDefaultStory from './RadioGroupStory';
+import {ThemeProvider} from '../../../main/theme';
+import {storiesOf} from '@storybook/react-native';
+
+/**
+ * Below are stories for web
+ */
+export default {
+  title: 'RadioGroup',
+};
+
+export const toStorybook = (): ReactElement => <RadioGroupDefaultStory />;
+
+toStorybook.story = {
+  name: 'radio button',
+};
+
+/**
+ * Below are stories for app
+ */
+storiesOf('RadioGroup', module)
+  .addDecorator(ContainerDeco)
+  .add('radio group - light', () => (
+    <ThemeProvider initialThemeType="light">
+      <RadioGroupDefaultStory />
+    </ThemeProvider>
+  ))
+  .add('radio group - dark', () => (
+    <ThemeProvider initialThemeType="dark">
+      <RadioGroupDefaultStory />
+    </ThemeProvider>
+  ));

--- a/stories/index.ts
+++ b/stories/index.ts
@@ -1,6 +1,7 @@
 import './dooboo-ui/TypographyStories';
 import './dooboo-ui/IconStories';
 import './dooboo-ui/LoadingIndicatorStories';
+import './dooboo-ui/RadioGroupStories';
 import './dooboo-ui/ButtonStories';
 import './dooboo-ui/IconButtonStories';
 import './dooboo-ui/CheckboxStories';


### PR DESCRIPTION
## Description

Design and implement [RadioGroup] to `main` component. This component is designed to access [RadioGroup] which has [RadioButton] as children. [RadioGroup] controls [RadioButton] so that only one of them is selected. However, if you want to use only [RadioButton] UI, it would be possible just by importing it without [RadioGroup].

![radio](https://user-images.githubusercontent.com/27461460/120981808-001e6f00-c7b3-11eb-881c-59d696a02f80.gif)

## Tests
Cover all test cases for [RadioGroup] and [RadioButton].

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
