### PR TITLE
Provide easier font installation for rn-cli

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,5 +1,11 @@
 ## Changelogs
 
+## 0.1.12
+
+Installing `dooboo-ui` font is hard to install for `react-native cli`. Make this process easier by installing it with `yarn react-native link`.
+
+Fix [Icon] to receive `color` and `style` props.
+
 ## 0.1.11
 
 Minor fix in styles.

--- a/README.md
+++ b/README.md
@@ -85,17 +85,7 @@ You can install our font to use in your project. This is recommended since we us
 
 - For React Native user
 
-  1. Create `react-native.config.js` file and add below code.
-
-     ```diff
-     module.exports = {
-       project: {
-         ios: {},
-         android: {},
-       },
-     +  assets: ['dooboo-ui/Icon/doobooui.ttf'],
-     };
-     ```
+  1. Install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
 
   2. Run `yarn react-native link`.
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.11",
+  "version": "0.1.12-rc.4",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.12-rc.4",
+  "version": "0.1.12",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/Icon/index.tsx
+++ b/main/Icon/index.tsx
@@ -43,5 +43,5 @@ const Ico: FC<Props> = createIconSetFromIcoMoon(
 );
 
 export const Icon = styled(Ico)`
-  color: ${({theme}) => theme.text};
+  color: ${({theme, color}) => color || theme.text};
 `;

--- a/main/Icon/index.tsx
+++ b/main/Icon/index.tsx
@@ -1,4 +1,5 @@
 import {FC} from 'react';
+import {ViewStyle} from 'react-native';
 import collectingFontIconSelection from './selection.json';
 import {createIconSetFromIcoMoon} from 'react-native-vector-icons';
 import styled from '@emotion/native';
@@ -34,6 +35,7 @@ type Props = {
   name: IconName;
   size?: number;
   color?: string;
+  style?: ViewStyle;
 };
 
 const Ico: FC<Props> = createIconSetFromIcoMoon(

--- a/main/react-native.config.js
+++ b/main/react-native.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  dependency: {
+    assets: ['Icon'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest",
     "test:all": "lerna run build && yarn lint && yarn tsc && jest",
     "test:post": "jest",
-    "build": "rm -f ./lib/tsconfigBuild.tsbuildinfo && cp README.md ./lib/README.md && tsc --project tsconfigBuild.json && yarn cp:icon",
+    "build": "cp ./main/react-native.config.js ./lib/react-native.config.js && rm -f ./lib/tsconfigBuild.tsbuildinfo && cp README.md ./lib/README.md && tsc --project tsconfigBuild.json && yarn cp:icon",
     "cp:icon": "cp ./main/Icon/selection.json ./lib/Icon/selection.json && cp ./main/Icon/doobooui.ttf ./lib/Icon/doobooui.ttf",
     "postbuild": "cp -r main/__assets__ lib/__assets__",
     "build:storybook": "expo build:web && sh web-build-postinstall.sh",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,6 @@
     "stories/dooboo-ui/**/*.tsx",
     "stories/packages/**/*.ts",
     "stories/packages/**/*.tsx"
-
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Description

Installing `dooboo-ui` font is hard to install for `react-native cli`. Make this process easier by installing it with `yarn react-native link`.

Fix [Icon] to receive `color` and `style` props.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
