### PR TITLE
Fix edit text styles

### DIFF
--- a/main/EditText.tsx
+++ b/main/EditText.tsx
@@ -80,7 +80,6 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
   const hovered = useHover(ref);
 
   const borderColor = theme.text;
-  const hoveredColor = theme.primary;
   const textColor = theme.text;
 
   const compositeStyles: Styles =
@@ -100,7 +99,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           hovered: [
             {
               borderBottomWidth: 2,
-              borderBottomColor: hoveredColor,
+              borderBottomColor: hoverColor,
             },
             styles?.hovered,
           ],
@@ -115,7 +114,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           labelTextHovered: [
             {
               paddingHorizontal: 4,
-              color: hoveredColor,
+              color: hoverColor,
             },
             styles?.labelTextHovered,
           ],
@@ -153,7 +152,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           ],
           hovered: [
             {
-              borderBottomColor: hoveredColor,
+              borderBottomColor: hoverColor,
               borderBottomWidth: 2,
             },
             styles?.hovered,
@@ -168,7 +167,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           ],
           labelTextHovered: [
             {
-              color: hoveredColor,
+              color: hoverColor,
             },
             styles?.labelTextHovered,
           ],
@@ -206,7 +205,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           hovered: [
             {
               borderWidth: 1,
-              borderColor: hoveredColor,
+              borderColor: hoverColor,
             },
             styles?.hovered,
           ],
@@ -222,7 +221,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           labelTextHovered: [
             {
               paddingHorizontal: 4,
-              color: hoveredColor,
+              color: hoverColor,
             },
             styles?.labelTextHovered,
           ],
@@ -263,10 +262,10 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           {
             borderColor: !editable
               ? disableColor
-              : hovered && !focused
-              ? hoverColor
               : errorText
               ? errorColor
+              : hovered && !focused
+              ? hoverColor
               : focused
               ? focusColor
               : borderColor,
@@ -274,10 +273,10 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           type !== 'boxed' && {
             borderBottomColor: !editable
               ? disableColor
-              : hovered && !focused
-              ? hoverColor
               : errorText
               ? errorColor
+              : hovered && !focused
+              ? hoverColor
               : focused
               ? focusColor
               : borderColor,
@@ -292,6 +291,8 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
                 ? {color: disableColor}
                 : errorText
                 ? {color: errorColor}
+                : hovered && !focused
+                ? {color: hoverColor}
                 : focused
                 ? {color: focusColor}
                 : {},

--- a/main/EditText.tsx
+++ b/main/EditText.tsx
@@ -259,7 +259,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
       <View
         style={[
           compositeStyles.container,
-          editable && hovered && [compositeStyles.hovered, styles?.hovered],
+          editable && hovered && compositeStyles.hovered,
           {
             borderColor: !editable
               ? disableColor
@@ -287,18 +287,14 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           <Text
             style={[
               compositeStyles.labelText,
-              styles?.labelText,
-              hovered && editable
-                ? [compositeStyles.labelTextHovered, styles?.labelTextHovered]
-                : editable
-                ? {
-                    color: errorText
-                      ? errorColor
-                      : focused
-                      ? focusColor
-                      : disableColor,
-                  }
-                : {color: disableColor},
+              hovered && editable && compositeStyles.labelTextHovered,
+              !editable
+                ? {color: disableColor}
+                : errorText
+                ? {color: errorColor}
+                : focused
+                ? {color: focusColor}
+                : {},
             ]}>
             {labelText}
           </Text>
@@ -310,7 +306,6 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           secureTextEntry={secureTextEntry}
           style={[
             compositeStyles.input,
-            styles?.input,
             // @ts-ignore
             Platform.OS === 'web' && {outlineWidth: 0},
           ]}

--- a/main/EditText.tsx
+++ b/main/EditText.tsx
@@ -263,7 +263,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           {
             borderColor: !editable
               ? disableColor
-              : hovered
+              : hovered && !focused
               ? hoverColor
               : errorText
               ? errorColor
@@ -274,7 +274,7 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
           type !== 'boxed' && {
             borderBottomColor: !editable
               ? disableColor
-              : hovered
+              : hovered && !focused
               ? hoverColor
               : errorText
               ? errorColor

--- a/main/__tests__/EditText.test.tsx
+++ b/main/__tests__/EditText.test.tsx
@@ -84,7 +84,7 @@ describe('[EditText]', () => {
           );
 
           const label = testingLib.getByText('label text');
-          const labelTextStyle = label.props.style[1];
+          const labelTextStyle = label.props.style[0][1];
 
           expect(labelTextStyle).toEqual({color: 'green'});
         });
@@ -94,25 +94,28 @@ describe('[EditText]', () => {
             jest.spyOn(RNWebHooks, 'useHover').mockImplementation(() => false);
           });
 
-          it('should contain `disableColor` - default', async () => {
-            testingLib = render(
-              component({
-                labelText: 'label text',
-                styles: {
-                  labelText: {
-                    color: 'green',
-                  },
-                },
-                disableColor: '#666',
-              }),
-            );
+          // wrong test written to prove wrong code
+          // it('should contain `disableColor` - default', async () => {
+          //   testingLib = render(
+          //     component({
+          //       labelText: 'label text',
+          //       styles: {
+          //         labelText: {
+          //           color: 'green',
+          //         },
+          //       },
+          //       disableColor: '#666',
+          //     }),
+          //   );
 
-            const label = testingLib.getByText('label text');
+          //   const label = testingLib.getByText('label text');
 
-            const unhoveredTextStyle = label.props.style[2];
+          //   const unhoveredTextStyle = label.props.style[1];
 
-            expect(unhoveredTextStyle).toEqual({color: '#666'});
-          });
+          //   console.log(label.props.style);
+
+          //   expect(unhoveredTextStyle).toEqual({color: '#666'});
+          // });
 
           it('should contain `focusColor` when focused', async () => {
             testingLib = render(

--- a/main/__tests__/EditText.test.tsx
+++ b/main/__tests__/EditText.test.tsx
@@ -94,29 +94,6 @@ describe('[EditText]', () => {
             jest.spyOn(RNWebHooks, 'useHover').mockImplementation(() => false);
           });
 
-          // wrong test written to prove wrong code
-          // it('should contain `disableColor` - default', async () => {
-          //   testingLib = render(
-          //     component({
-          //       labelText: 'label text',
-          //       styles: {
-          //         labelText: {
-          //           color: 'green',
-          //         },
-          //       },
-          //       disableColor: '#666',
-          //     }),
-          //   );
-
-          //   const label = testingLib.getByText('label text');
-
-          //   const unhoveredTextStyle = label.props.style[1];
-
-          //   console.log(label.props.style);
-
-          //   expect(unhoveredTextStyle).toEqual({color: '#666'});
-          // });
-
           it('should contain `focusColor` when focused', async () => {
             testingLib = render(
               component({

--- a/main/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/main/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`[EditText] interactions !editable renders \`errorText\` 1`] = `
             },
             undefined,
           ],
-          undefined,
+          false,
           Object {
             "color": "#C4C4C4",
           },
@@ -77,7 +77,6 @@ exports[`[EditText] interactions !editable renders \`errorText\` 1`] = `
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -135,7 +134,7 @@ exports[`[EditText] interactions !editable renders \`labelText\` 1`] = `
             },
             undefined,
           ],
-          undefined,
+          false,
           Object {
             "color": "#C4C4C4",
           },
@@ -165,7 +164,6 @@ exports[`[EditText] interactions !editable renders \`labelText\` 1`] = `
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -233,7 +231,6 @@ exports[`[EditText] interactions !editable renders without crashing 1`] = `
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -301,7 +298,6 @@ exports[`[EditText] interactions Type: [boxed] should render \`!editable\` statu
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -390,7 +386,6 @@ exports[`[EditText] interactions Type: [boxed] should render \`errorText\` 1`] =
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -479,7 +474,6 @@ exports[`[EditText] interactions Type: [boxed] should render without crashing 1`
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -568,7 +562,6 @@ exports[`[EditText] interactions Type: [column] - default renders custom styles 
             },
             Object {},
           ],
-          Object {},
           false,
         ]
       }
@@ -657,7 +650,6 @@ exports[`[EditText] interactions Type: [column] - default renders without crashi
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -746,7 +738,6 @@ exports[`[EditText] interactions Type: [row] should render \`!editable\` status 
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -835,7 +826,6 @@ exports[`[EditText] interactions Type: [row] should render \`errorText\` 1`] = `
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -924,7 +914,6 @@ exports[`[EditText] interactions Type: [row] should render without crashing 1`] 
             },
             undefined,
           ],
-          undefined,
           false,
         ]
       }
@@ -1013,7 +1002,6 @@ exports[`[EditText] interactions web renders without crashing 1`] = `
             },
             undefined,
           ],
-          undefined,
           Object {
             "outlineWidth": 0,
           },


### PR DESCRIPTION
## Description

There happened to be an error which text color styles prop of EditText component doesn't work properly
while I try to change labelText color of 'Hackatalk' app.

There seemed to be error in ternary operator and redundancy between compositeStyles and style props of Text component.

So I fixed all the style code related 

(sorry this is my first pull request^^;;)

## Related Issues

_Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR._

## Tests

Updated test code and snapshot accordingly

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
