### PR TITLE
Enhance `typings` in [ButtonGroup] to receive different props for data

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,5 +1,9 @@
 ## Changelogs
 
+## 0.1.19
+
+Enhance `typings` in [ButtonGroup] to receive different props for data.
+
 ## 0.1.18
 
 Add `comment-light` icon to `dooboo-ui` Icon.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/ButtonGroup.tsx
+++ b/main/ButtonGroup.tsx
@@ -1,5 +1,5 @@
 import {DoobooTheme, light, useTheme, withTheme} from './theme';
-import React, {FC, useState} from 'react';
+import React, {useState} from 'react';
 import {
   StyleProp,
   StyleSheet,
@@ -18,20 +18,20 @@ interface Styles {
   selectedText: StyleProp<TextStyle>;
 }
 
-interface Props {
+interface Props<T> {
   testID?: string;
   theme: DoobooTheme;
   borderRadius?: number;
   borderWidth?: number;
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
-  data: string[];
+  data: T[];
   color?: string;
   onPress?: (i: number) => void;
   initialIndex?: number;
 }
 
-const StyledButtonGroup: FC<Props> = (props) => {
+function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
   const {theme} = useTheme();
 
   const {
@@ -111,7 +111,7 @@ const StyledButtonGroup: FC<Props> = (props) => {
       })}
     </View>
   );
-};
+}
 
 StyledButtonGroup.defaultProps = {
   theme: light,
@@ -153,4 +153,4 @@ StyledButtonGroup.defaultProps = {
   data: ['option 1', 'option 2'],
 };
 
-export const ButtonGroup = withTheme(StyledButtonGroup);
+export const ButtonGroup = withTheme<any>(StyledButtonGroup);


### PR DESCRIPTION

Enhance `typings` in [ButtonGroup] to receive different props for data.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
