### PR TITLE
Fix typo in [Accordion] test

### DIFF
--- a/main/__tests__/Accordion.test.tsx
+++ b/main/__tests__/Accordion.test.tsx
@@ -24,7 +24,7 @@ const data = [
 ];
 
 describe('[Accordion] render test', () => {
-  it('should render without crasing', () => {
+  it('should render without crashing', () => {
     props = createTestProps({data: data});
 
     component = createComponent(<Accordion {...props} />);

--- a/main/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/main/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -1716,7 +1716,7 @@ exports[`[Accordion] render test should render collapsed when collapseOnStart pr
 </View>
 `;
 
-exports[`[Accordion] render test should render without crasing 1`] = `
+exports[`[Accordion] render test should render without crashing 1`] = `
 <View
   style={
     Array [


### PR DESCRIPTION

## Description
I fixed simple typo. (`crasing -> crashing`)

Although the word `crashing` is repeatedly used in this project,  from the perspective of someone unfamiliar with this project, it might be confusing. (`What is crasing?`)

## Related Issues
none.

## Tests
I just updated snapshot.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.