### PR TITLE
Fix import stories/package/CalendarCarousel directory

### DIFF
--- a/stories/packages/CalendarCarouselStories/index.tsx
+++ b/stories/packages/CalendarCarouselStories/index.tsx
@@ -3,7 +3,7 @@ import 'intl/locale-data/jsonp/en';
 
 import React, {ReactElement, useState} from 'react';
 
-import CalendarCarousel from '../../../packages/CalendarCarousel/lib';
+import CalendarCarousel from '../../../packages/CalendarCarousel';
 import {ContainerDeco} from '../../../storybook/decorators';
 import {storiesOf} from '@storybook/react-native';
 import styled from '@emotion/native';


### PR DESCRIPTION
## Description

Error occurs at `yarn start` after initial git clone.
There is no `lib` in the **packages/CalendarCarousel** directory.

## Related Issues

X

## Tests

X

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
