### PR TITLE
Add label and disabled form for each checkbox type

### DIFF
--- a/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
+++ b/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
@@ -41,20 +41,28 @@ const CheckboxStory: FC = () => {
       <View style={{flexDirection: 'row'}}>
         {types.map((type) => (
           <>
-            <Checkbox
-              checked={checked}
-              onPress={() => setChecked(!checked)}
-              type={type}
-            />
-            <View style={{width: 8}} />
+            <View
+              style={{
+                flexDirection: 'column',
+                alignItems: 'center',
+              }}>
+              <StyledText>{type ?? 'default'}</StyledText>
+
+              <Checkbox
+                checked={checked}
+                onPress={() => setChecked(!checked)}
+                type={type}
+              />
+              <Checkbox
+                checked={checked}
+                onPress={() => setChecked(!checked)}
+                type={type}
+                disabled
+              />
+            </View>
+            <View style={{width: 20}} />
           </>
         ))}
-
-        <Checkbox
-          checked={checked}
-          onPress={() => setChecked(!checked)}
-          disabled
-        />
       </View>
     </>
   );

--- a/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
+++ b/stories/dooboo-ui/CheckboxStories/CheckboxStory.tsx
@@ -1,5 +1,5 @@
 import {Checkbox, CheckboxType, Hr, useTheme} from '../../../main';
-import {FC, useState} from 'react';
+import {FC, ReactNode, useState} from 'react';
 
 import {View} from 'react-native';
 import styled from '@emotion/native';
@@ -13,6 +13,30 @@ const StyledText = styled.Text`
   color: ${({theme}) => theme.text};
 `;
 
+const types: (CheckboxType | undefined)[] = [
+  undefined,
+  'secondary',
+  'success',
+  'warning',
+  'info',
+  'danger',
+];
+
+const LabelWapper: FC<{
+  label: string;
+  children: ReactNode;
+}> = ({label, children}) => (
+  <View
+    style={{
+      flexDirection: 'column',
+      alignItems: 'center',
+    }}>
+    <StyledText>{label}</StyledText>
+
+    {children}
+  </View>
+);
+
 const CheckboxStory: FC = () => {
   const [checked, setChecked] = useState<boolean>(false);
   const {theme} = useTheme();
@@ -23,15 +47,6 @@ const CheckboxStory: FC = () => {
 
   if (!fontsLoaded) return <View />;
 
-  const types: (CheckboxType | undefined)[] = [
-    undefined,
-    'secondary',
-    'success',
-    'warning',
-    'info',
-    'danger',
-  ];
-
   const CheckboxForms: FC = () => (
     <>
       <StyledText style={{fontSize: 18, marginTop: 24, marginBottom: 12}}>
@@ -41,28 +56,25 @@ const CheckboxStory: FC = () => {
       <View style={{flexDirection: 'row'}}>
         {types.map((type) => (
           <>
-            <View
-              style={{
-                flexDirection: 'column',
-                alignItems: 'center',
-              }}>
-              <StyledText>{type ?? 'default'}</StyledText>
+            <LabelWapper label={type ?? 'default'}>
+              <Checkbox
+                checked={checked}
+                onPress={() => setChecked(!checked)}
+                type={type}
+              />
+            </LabelWapper>
 
-              <Checkbox
-                checked={checked}
-                onPress={() => setChecked(!checked)}
-                type={type}
-              />
-              <Checkbox
-                checked={checked}
-                onPress={() => setChecked(!checked)}
-                type={type}
-                disabled
-              />
-            </View>
-            <View style={{width: 20}} />
+            <View style={{width: 22}} />
           </>
         ))}
+
+        <LabelWapper label="disabled">
+          <Checkbox
+            checked={checked}
+            onPress={() => setChecked(!checked)}
+            disabled
+          />
+        </LabelWapper>
       </View>
     </>
   );


### PR DESCRIPTION
## Description
1. Storybook of other component such as [RadioGroup] has label for each type. [Checkbox] needs it too.
2. Some might curious, "What does disabled button looks like for each type?" So it's better to show them on storybook.

![무제](https://user-images.githubusercontent.com/61503739/128618686-33eedf59-a384-4e10-b559-790018b995a0.jpeg)

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
