### PR TITLE
Fix borderRadius-related bug in [ButtonGroup]

### DIFF
--- a/main/ButtonGroup.tsx
+++ b/main/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import {DoobooTheme, light, useTheme, withTheme} from './theme';
+import {useTheme, withTheme} from './theme';
 import {
   StyleProp,
   StyleSheet,
@@ -18,36 +18,84 @@ interface Styles {
 }
 
 interface Props<T> {
-  testID?: string;
-  theme: DoobooTheme;
+  data: T[];
+  selectedIndex?: number;
+  onPress?: (i: number) => void;
   borderRadius?: number;
   borderWidth?: number;
+  color?: string;
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
-  data: T[];
-  color?: string;
-  onPress?: (i: number) => void;
-  selectedIndex?: number;
 }
 
 function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
   const {theme} = useTheme();
 
   const {
-    borderRadius = 0,
+    data,
     selectedIndex = 0,
+    onPress,
+    borderRadius = 0,
     borderWidth = 1,
     color = theme.text,
-    testID,
     style,
-    data,
-    onPress,
     styles,
   } = props;
 
+  const borderWidthAndRadius = (index: number): object => {
+    const fullWidthAndRadius = {
+      borderLeftWidth: borderWidth,
+      borderRightWidth: borderWidth,
+      borderTopWidth: borderWidth,
+      borderBottomWidth: borderWidth,
+
+      borderTopLeftRadius: borderRadius,
+      borderBottomLeftRadius: borderRadius,
+      borderTopRightRadius: borderRadius,
+      borderBottomRightRadius: borderRadius,
+    };
+
+    const isFirst = index === 0;
+    const isLast = index === data.length - 1;
+
+    const borderForFirstElement = {
+      ...fullWidthAndRadius,
+      borderTopRightRadius: undefined,
+      borderBottomRightRadius: undefined,
+    };
+
+    const borderForLastElement = {
+      ...fullWidthAndRadius,
+      borderTopLeftRadius: undefined,
+      borderBottomLeftRadius: undefined,
+    };
+
+    const borderForMiddleElement = {
+      borderRightWidth: borderWidth,
+      borderTopWidth: borderWidth,
+      borderBottomWidth: borderWidth,
+    };
+
+    if (data.length === 1) return fullWidthAndRadius;
+
+    if (isFirst) return borderForFirstElement;
+
+    if (isLast) {
+      if (data.length === 2)
+        return {
+          ...borderForLastElement,
+          borderLeftWidth: undefined,
+        };
+
+      return borderForLastElement;
+    }
+
+    return borderForMiddleElement;
+  };
+
   return (
     <View
-      testID={testID}
+      testID="container"
       style={StyleSheet.flatten([
         {borderColor: color},
         styles?.container,
@@ -57,39 +105,18 @@ function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
         return (
           <TouchableOpacity
             key={i}
-            testID={`CHILD_${i}`}
             activeOpacity={0.85}
             style={{flex: 1}}
             onPress={(): void => {
               if (onPress) onPress(i);
             }}>
             <View
+              testID={`element_${i}`}
               style={StyleSheet.flatten([
                 selectedIndex === i
                   ? {...styles?.selectedButton, backgroundColor: color}
                   : {...styles?.button, borderColor: color},
-                i === 0
-                  ? {
-                      borderLeftWidth: borderWidth,
-                      borderTopWidth: borderWidth,
-                      borderBottomWidth: borderWidth,
-                      borderTopLeftRadius: borderRadius,
-                      borderBottomLeftRadius: borderRadius,
-                    }
-                  : i === data.length - 1
-                  ? {
-                      borderRightWidth: borderWidth,
-                      borderLeftWidth: borderWidth,
-                      borderTopWidth: borderWidth,
-                      borderBottomWidth: borderWidth,
-                      borderBottomRightRadius: borderRadius,
-                      borderTopRightRadius: borderRadius,
-                    }
-                  : {
-                      borderLeftWidth: borderWidth,
-                      borderTopWidth: borderWidth,
-                      borderBottomWidth: borderWidth,
-                    },
+                borderWidthAndRadius(i),
                 {borderColor: color},
               ])}>
               <Text
@@ -109,7 +136,6 @@ function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
 }
 
 StyledButtonGroup.defaultProps = {
-  theme: light,
   styles: {
     container: {
       backgroundColor: 'transparent',
@@ -145,7 +171,6 @@ StyledButtonGroup.defaultProps = {
       alignSelf: 'center',
     },
   },
-  data: ['option 1', 'option 2'],
 };
 
 export const ButtonGroup = withTheme<any>(StyledButtonGroup);

--- a/main/ButtonGroup.tsx
+++ b/main/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import {useTheme, withTheme} from './theme';
+import {DoobooTheme, light, useTheme, withTheme} from './theme';
 import {
   StyleProp,
   StyleSheet,
@@ -18,27 +18,30 @@ interface Styles {
 }
 
 interface Props<T> {
-  data: T[];
-  selectedIndex?: number;
-  onPress?: (i: number) => void;
+  testID?: string;
+  theme: DoobooTheme;
   borderRadius?: number;
   borderWidth?: number;
-  color?: string;
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
+  data: T[];
+  color?: string;
+  onPress?: (i: number) => void;
+  selectedIndex?: number;
 }
 
 function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
   const {theme} = useTheme();
 
   const {
-    data,
-    selectedIndex = 0,
-    onPress,
     borderRadius = 0,
+    selectedIndex = 0,
     borderWidth = 1,
     color = theme.text,
+    testID,
     style,
+    data,
+    onPress,
     styles,
   } = props;
 
@@ -95,7 +98,7 @@ function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
 
   return (
     <View
-      testID="container"
+      testID={testID}
       style={StyleSheet.flatten([
         {borderColor: color},
         styles?.container,
@@ -111,7 +114,7 @@ function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
               if (onPress) onPress(i);
             }}>
             <View
-              testID={`element_${i}`}
+              testID={`CHILD_${i}`}
               style={StyleSheet.flatten([
                 selectedIndex === i
                   ? {...styles?.selectedButton, backgroundColor: color}
@@ -136,6 +139,7 @@ function StyledButtonGroup<T>(props: Props<T>): React.ReactElement {
 }
 
 StyledButtonGroup.defaultProps = {
+  theme: light,
   styles: {
     container: {
       backgroundColor: 'transparent',
@@ -171,6 +175,7 @@ StyledButtonGroup.defaultProps = {
       alignSelf: 'center',
     },
   },
+  data: ['option 1', 'option 2'],
 };
 
 export const ButtonGroup = withTheme<any>(StyledButtonGroup);

--- a/main/__tests__/ButtonGroup.test.tsx
+++ b/main/__tests__/ButtonGroup.test.tsx
@@ -31,7 +31,7 @@ describe('[ButtonGroup]', () => {
   });
 
   it('renders without crashing', () => {
-    const props = createTestProps({data: ['Option 1']});
+    const props = createTestProps();
 
     const testingLib = render(createComponent(<ButtonGroup {...props} />));
 
@@ -98,7 +98,7 @@ describe('[ButtonGroup]', () => {
       it('has width and radius in every direction', () => {
         const {getByTestId} = renderButtonGroup();
 
-        expect(getByTestId('element_0')).toHaveStyle(fullWidthAndRadius);
+        expect(getByTestId('CHILD_0')).toHaveStyle(fullWidthAndRadius);
       });
     });
 
@@ -108,25 +108,25 @@ describe('[ButtonGroup]', () => {
       it('depends on position of element', () => {
         const {getByTestId} = renderButtonGroup();
 
-        expect(getByTestId('element_0')).toHaveStyle({
+        expect(getByTestId('CHILD_0')).toHaveStyle({
           ...fullWidthAndRadius,
           borderTopRightRadius: undefined,
           borderBottomRightRadius: undefined,
         });
 
-        expect(getByTestId('element_0')).not.toHaveStyle({
+        expect(getByTestId('CHILD_0')).not.toHaveStyle({
           borderTopRightRadius: 10,
           borderBottomRightRadius: 10,
         });
 
-        expect(getByTestId('element_1')).toHaveStyle({
+        expect(getByTestId('CHILD_1')).toHaveStyle({
           ...fullWidthAndRadius,
           borderLeftWidth: undefined,
           borderTopLeftRadius: undefined,
           borderBottomLeftRadius: undefined,
         });
 
-        expect(getByTestId('element_1')).not.toHaveStyle({
+        expect(getByTestId('CHILD_1')).not.toHaveStyle({
           borderLeftWidth: 1,
           borderTopLeftRadius: 10,
           borderBottomLeftRadius: 10,
@@ -140,37 +140,37 @@ describe('[ButtonGroup]', () => {
       it('depends on position of element', () => {
         const {getByTestId} = renderButtonGroup();
 
-        expect(getByTestId('element_0')).toHaveStyle({
+        expect(getByTestId('CHILD_0')).toHaveStyle({
           ...fullWidthAndRadius,
           borderTopRightRadius: undefined,
           borderBottomRightRadius: undefined,
         });
 
-        expect(getByTestId('element_0')).not.toHaveStyle({
+        expect(getByTestId('CHILD_0')).not.toHaveStyle({
           borderTopRightRadius: 10,
           borderBottomRightRadius: 10,
         });
 
-        expect(getByTestId('element_1')).toHaveStyle({
+        expect(getByTestId('CHILD_1')).toHaveStyle({
           borderRightWidth: 1,
           borderTopWidth: 1,
           borderBottomWidth: 1,
         });
 
-        expect(getByTestId('element_1')).not.toHaveStyle({
+        expect(getByTestId('CHILD_1')).not.toHaveStyle({
           ...fullWidthAndRadius,
           borderRightWidth: undefined,
           borderTopWidth: undefined,
           borderBottomWidth: undefined,
         });
 
-        expect(getByTestId('element_2')).toHaveStyle({
+        expect(getByTestId('CHILD_2')).toHaveStyle({
           ...fullWidthAndRadius,
           borderTopLeftRadius: undefined,
           borderBottomLeftRadius: undefined,
         });
 
-        expect(getByTestId('element_2')).not.toHaveStyle({
+        expect(getByTestId('CHILD_2')).not.toHaveStyle({
           borderTopLeftRadius: 10,
           borderBottomLeftRadius: 10,
         });

--- a/main/__tests__/ButtonGroup.test.tsx
+++ b/main/__tests__/ButtonGroup.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-identical-title */
 import {fireEvent, render, RenderAPI} from '@testing-library/react-native';
 import {createComponent, createTestProps} from '../../test/testUtils';
 
@@ -10,13 +11,17 @@ describe('[ButtonGroup]', () => {
 
   const handlePress = jest.fn();
 
-  const renderButtonGroup = (i?: number): RenderAPI =>
+  const renderButtonGroup = (): RenderAPI =>
     render(
       <ThemeProvider initialThemeType={themeType}>
         <ButtonGroup
-          selectedIndex={i}
-          data={['option 1', 'option 2']}
+          data={given.data ?? ['option 1', 'option 2']}
+          selectedIndex={given.selectedIndex}
           onPress={handlePress}
+          borderWidth={given.borderWidth}
+          borderRadius={given.borderRadius}
+          style={given.style}
+          styles={given.styles}
         />
       </ThemeProvider>,
     );
@@ -26,7 +31,7 @@ describe('[ButtonGroup]', () => {
   });
 
   it('renders without crashing', () => {
-    const props = createTestProps();
+    const props = createTestProps({data: ['Option 1']});
 
     const testingLib = render(createComponent(<ButtonGroup {...props} />));
 
@@ -56,10 +61,10 @@ describe('[ButtonGroup]', () => {
   });
 
   context('when selectedIndex is provided', () => {
-    const selectedIndex = 1;
+    given('selectedIndex', () => 1);
 
     it('makes selected option text notable', () => {
-      const {getByText} = renderButtonGroup(selectedIndex);
+      const {getByText} = renderButtonGroup();
 
       expect(getByText('option 1')).toHaveStyle({
         color: theme[themeType].text,
@@ -67,6 +72,108 @@ describe('[ButtonGroup]', () => {
 
       expect(getByText('option 2')).toHaveStyle({
         color: theme[themeType].textContrast,
+      });
+    });
+  });
+
+  describe('Border', () => {
+    given('borderWidth', () => 1);
+    given('borderRadius', () => 10);
+
+    const fullWidthAndRadius = {
+      borderLeftWidth: 1,
+      borderRightWidth: 1,
+      borderTopWidth: 1,
+      borderBottomWidth: 1,
+
+      borderTopLeftRadius: 10,
+      borderTopRightRadius: 10,
+      borderBottomLeftRadius: 10,
+      borderBottomRightRadius: 10,
+    };
+
+    context('when data size is 1', () => {
+      given('data', () => ['Option 1']);
+
+      it('has width and radius in every direction', () => {
+        const {getByTestId} = renderButtonGroup();
+
+        expect(getByTestId('element_0')).toHaveStyle(fullWidthAndRadius);
+      });
+    });
+
+    context('when data size is 2', () => {
+      given('data', () => ['Option 1', 'Option 2']);
+
+      it('depends on position of element', () => {
+        const {getByTestId} = renderButtonGroup();
+
+        expect(getByTestId('element_0')).toHaveStyle({
+          ...fullWidthAndRadius,
+          borderTopRightRadius: undefined,
+          borderBottomRightRadius: undefined,
+        });
+
+        expect(getByTestId('element_0')).not.toHaveStyle({
+          borderTopRightRadius: 10,
+          borderBottomRightRadius: 10,
+        });
+
+        expect(getByTestId('element_1')).toHaveStyle({
+          ...fullWidthAndRadius,
+          borderLeftWidth: undefined,
+          borderTopLeftRadius: undefined,
+          borderBottomLeftRadius: undefined,
+        });
+
+        expect(getByTestId('element_1')).not.toHaveStyle({
+          borderLeftWidth: 1,
+          borderTopLeftRadius: 10,
+          borderBottomLeftRadius: 10,
+        });
+      });
+    });
+
+    context('when data size is 3', () => {
+      given('data', () => ['Option 1', 'Option 2', 'Option 3']);
+
+      it('depends on position of element', () => {
+        const {getByTestId} = renderButtonGroup();
+
+        expect(getByTestId('element_0')).toHaveStyle({
+          ...fullWidthAndRadius,
+          borderTopRightRadius: undefined,
+          borderBottomRightRadius: undefined,
+        });
+
+        expect(getByTestId('element_0')).not.toHaveStyle({
+          borderTopRightRadius: 10,
+          borderBottomRightRadius: 10,
+        });
+
+        expect(getByTestId('element_1')).toHaveStyle({
+          borderRightWidth: 1,
+          borderTopWidth: 1,
+          borderBottomWidth: 1,
+        });
+
+        expect(getByTestId('element_1')).not.toHaveStyle({
+          ...fullWidthAndRadius,
+          borderRightWidth: undefined,
+          borderTopWidth: undefined,
+          borderBottomWidth: undefined,
+        });
+
+        expect(getByTestId('element_2')).toHaveStyle({
+          ...fullWidthAndRadius,
+          borderTopLeftRadius: undefined,
+          borderBottomLeftRadius: undefined,
+        });
+
+        expect(getByTestId('element_2')).not.toHaveStyle({
+          borderTopLeftRadius: 10,
+          borderBottomLeftRadius: 10,
+        });
       });
     });
   });

--- a/main/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/main/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
       "minHeight": 40,
     }
   }
+  testID="container"
 >
   <View
     accessible={true}
@@ -31,7 +32,6 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
         "opacity": 1,
       }
     }
-    testID="CHILD_0"
   >
     <View
       style={
@@ -40,15 +40,19 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
           "alignSelf": "stretch",
           "backgroundColor": "black",
           "borderBottomLeftRadius": 0,
+          "borderBottomRightRadius": 0,
           "borderBottomWidth": 1,
           "borderColor": "black",
           "borderLeftWidth": 1,
+          "borderRightWidth": 1,
           "borderTopLeftRadius": 0,
+          "borderTopRightRadius": 0,
           "borderTopWidth": 1,
           "justifyContent": "center",
           "minHeight": 40,
         }
       }
+      testID="element_0"
     >
       <Text
         style={
@@ -64,60 +68,7 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
           ]
         }
       >
-        option 1
-      </Text>
-    </View>
-  </View>
-  <View
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "flex": 1,
-        "opacity": 1,
-      }
-    }
-    testID="CHILD_1"
-  >
-    <View
-      style={
-        Object {
-          "alignItems": "center",
-          "alignSelf": "stretch",
-          "borderBottomRightRadius": 0,
-          "borderBottomWidth": 1,
-          "borderColor": "black",
-          "borderLeftWidth": 1,
-          "borderRightWidth": 1,
-          "borderTopRightRadius": 0,
-          "borderTopWidth": 1,
-          "justifyContent": "center",
-          "minHeight": 40,
-        }
-      }
-    >
-      <Text
-        style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "fontSize": 14,
-              "textAlign": "center",
-            },
-            Object {
-              "color": "black",
-            },
-          ]
-        }
-      >
-        option 2
+        Option 1
       </Text>
     </View>
   </View>

--- a/main/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/main/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
       "minHeight": 40,
     }
   }
-  testID="container"
 >
   <View
     accessible={true}
@@ -40,19 +39,19 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
           "alignSelf": "stretch",
           "backgroundColor": "black",
           "borderBottomLeftRadius": 0,
-          "borderBottomRightRadius": 0,
+          "borderBottomRightRadius": undefined,
           "borderBottomWidth": 1,
           "borderColor": "black",
           "borderLeftWidth": 1,
           "borderRightWidth": 1,
           "borderTopLeftRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderTopRightRadius": undefined,
           "borderTopWidth": 1,
           "justifyContent": "center",
           "minHeight": 40,
         }
       }
-      testID="element_0"
+      testID="CHILD_0"
     >
       <Text
         style={
@@ -68,7 +67,62 @@ exports[`[ButtonGroup] renders without crashing 1`] = `
           ]
         }
       >
-        Option 1
+        option 1
+      </Text>
+    </View>
+  </View>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "flex": 1,
+        "opacity": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": 0,
+          "borderBottomWidth": 1,
+          "borderColor": "black",
+          "borderLeftWidth": undefined,
+          "borderRightWidth": 1,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": 0,
+          "borderTopWidth": 1,
+          "justifyContent": "center",
+          "minHeight": 40,
+        }
+      }
+      testID="CHILD_1"
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "fontSize": 14,
+              "textAlign": "center",
+            },
+            Object {
+              "color": "black",
+            },
+          ]
+        }
+      >
+        option 2
       </Text>
     </View>
   </View>

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "expo-font": "~9.2.1",
     "expo-linear-gradient": "~9.2.0",
     "gh-pages": "^3.2.3",
+    "givens": "^1.3.9",
     "intl": "^1.2.5",
     "jest": "^27.0.6",
     "jest-expo": "^42.1.0",

--- a/test/setupTest.ts
+++ b/test/setupTest.ts
@@ -4,6 +4,8 @@ import '@testing-library/jest-native/extend-expect';
 
 import 'jest-plugin-context/setup';
 
+import 'givens/setup';
+
 jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
 
 // Cleanup after each case.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10641,6 +10641,11 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
+givens@^1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/givens/-/givens-1.3.9.tgz#2061c02e01b1d0322e6854e6a99919bb91077a0d"
+  integrity sha512-4hYlStsEIaYeYvZTZwgD5yOS2WVP0dcDsOBqeImdEM8eLuclvv0IEMlQQ1kuA5DN4he7wVH1jsYtNe9uininxg==
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
## Description
1. See Top-Right and Botton-Right radius. It is not working properly when data size is 1.
So I write tests, fix bug, and refactor code.
(remove `chained ternaries` as mentioned in #45)
![이미지 2021  8  9  오후 10 50](https://user-images.githubusercontent.com/61503739/128725436-72ebaf54-7615-4cfe-85cc-bbcf77ae90f2.jpg)

2. In the process of fixing bug, I made trivial changes.

  - Move `CHILD_index` testID to make testing easier. 
  - ~~Remove useless `theme` prop / default value~~
  - ~~Remove `testID` prop~~
    ~~I don't think user need `testID` prop. It is applied to Outermost View wrapper. But why user need to get that? They might write test code relate to each button.  But they can to that with `getByText` or `element_index` testID. So it is no need to give them free to name it. Just name 'container' is fine for development use.~~
  - ~~Rename testID ([userInput - CHILD] -> [container - element])~~
     ~~I think `container - element` gives better abstraction.~~
 - ~~Data prop shouldn't be optional. I remove default value and make it required.~~


3. I use `givens` library. I will explain reasons in discussion soon.
Although it supports Typescript, I didn't define types because I think It's bit too much for test code.
```ts
import getGiven from 'givens';
interface myVars {
  var1: number; // the keys you intend to use
  var2: string; // and their types
}
const given = getGiven<myVars>();
```

## Related Issues
#45 

## Tests
I add tests to ensure [ButtonGroup] calculates proper `borderWidth` and `borderRadius`.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
