### PR TITLE
Detect orientation on media query

### DIFF
--- a/docs/src/styled.d.ts
+++ b/docs/src/styled.d.ts
@@ -3,6 +3,7 @@ import type {DoobooTheme} from 'dooboo-ui';
 
 declare module '@emotion/react' {
   export interface Theme extends DoobooTheme {
+    isPortrait?: boolean;
     isMobile?: boolean;
     isTablet?: boolean;
     isDesktop?: boolean;

--- a/main/theme/ThemeProvider.tsx
+++ b/main/theme/ThemeProvider.tsx
@@ -14,9 +14,10 @@ import {useMediaQuery} from 'react-responsive';
 interface Context {
   themeType: ColorSchemeName;
   media: {
-    isDesktop: boolean;
-    isTablet: boolean;
+    isPortrait: boolean;
     isMobile: boolean;
+    isTablet: boolean;
+    isDesktop: boolean;
   };
   theme: DefaultTheme;
   changeThemeType: (themeType?: ColorSchemeName) => void;
@@ -37,9 +38,11 @@ function ThemeProvider({
   initialThemeType,
   customTheme,
 }: Props): React.ReactElement {
+  const isPortrait = useMediaQuery({query: '(orientation: portrait)'});
   const isMobile = useMediaQuery({maxWidth: 767});
   const isTablet = useMediaQuery({minWidth: 767, maxWidth: 992});
   const isDesktop = useMediaQuery({minWidth: 992});
+
   const colorScheme = useColorScheme();
 
   const [themeType, setThemeType] = useState(initialThemeType || colorScheme);
@@ -64,6 +67,7 @@ function ThemeProvider({
       : {...light, ...customTheme?.light};
 
   const media = {
+    isPortrait,
     isMobile,
     isTablet,
     isDesktop,

--- a/main/theme/colors.ts
+++ b/main/theme/colors.ts
@@ -43,6 +43,7 @@ export const light = {
 };
 
 export type DoobooTheme = typeof light & {
+  isPortrait?: boolean;
   isDesktop?: boolean;
   isTablet?: boolean;
   isMobile?: boolean;

--- a/main/theme/styled.d.ts
+++ b/main/theme/styled.d.ts
@@ -3,6 +3,7 @@ import type {DoobooTheme} from './index';
 
 declare module '@emotion/react' {
   export interface Theme extends DoobooTheme {
+    isPortrait?: boolean;
     isMobile?: boolean;
     isTablet?: boolean;
     isDesktop?: boolean;


### PR DESCRIPTION
## Description

When testing the orientaion is not detected with `isMobile`, `isTablet` and `isDesktop` which we've defined. Therefore it looks we need to expose variable `isPortrait` to also detect the orientation.

Then we can provide different layouts in below cases.
<img width="280" alt="Screen Shot 2021-08-15 at 3 10 17 PM" src="https://user-images.githubusercontent.com/27461460/129469016-23670873-53b5-421b-9df0-c523186deb61.png">

<img width="280" alt="Screen Shot 2021-08-15 at 3 10 30 PM" src="https://user-images.githubusercontent.com/27461460/129469017-356a531d-9b47-4394-a332-8e40a6bd1592.png">


## Related Issues

N/A


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
