### PR TITLE
Add [Selectable]  

### DIFF
--- a/main/Selectable/index.tsx
+++ b/main/Selectable/index.tsx
@@ -1,0 +1,58 @@
+import React, {useState, ReactElement} from 'react';
+
+const Selectable = ({
+  children,
+  onPress,
+  mode = 'singleChoice',
+}): ReactElement => {
+  const initial = React.Children.map(
+    children ?? [],
+    (child) => !!child.props.selected,
+  );
+
+  const [selectedArray, setSelectedArray] = useState(initial);
+
+  const [selectedIndex, setSelectedIndex] = useState(
+    initial.findIndex((value: boolean) => value === true),
+  );
+
+  return React.Children.map(children, (child, i) => {
+    type NewProps = {
+      selected: boolean;
+      handlePress: Function;
+    };
+
+    const {selected, handlePress}: NewProps = {
+      checkbox: {
+        selected: selectedArray[i],
+        handlePress: () => {
+          const nextSelctedArray = [
+            ...selectedArray.slice(0, i),
+            !selectedArray[i],
+            ...selectedArray.slice(i + 1),
+          ];
+
+          setSelectedArray(nextSelctedArray);
+
+          if (onPress) onPress(nextSelctedArray);
+        },
+      },
+
+      singleChoice: {
+        selected: selectedIndex === i,
+        handlePress: () => {
+          setSelectedIndex(i);
+
+          if (onPress) onPress(i);
+        },
+      },
+    }[mode]!;
+
+    return React.cloneElement(child, {
+      selected,
+      onPress: handlePress,
+    });
+  });
+};
+
+export default Selectable;

--- a/main/__tests__/Selectable.test.tsx
+++ b/main/__tests__/Selectable.test.tsx
@@ -1,0 +1,105 @@
+import {Text} from 'react-native';
+import {toHaveTextContent} from '@testing-library/jest-native';
+import {fireEvent, render, RenderAPI} from '@testing-library/react-native';
+import getGiven from 'givens';
+
+import Selectable from '../Selectable/index';
+import {ReactElement} from 'react';
+
+type Mode = 'checkbox' | 'singleChoice';
+
+interface Variables {
+  mode: Mode;
+  onPress: any;
+}
+
+const given = getGiven<Variables>();
+
+interface Props {
+  testID?: string;
+  selected?: boolean;
+  onPress?: any;
+}
+
+const TestElement = ({testID, selected, onPress}: Props): ReactElement => (
+  <Text testID={testID} onPress={onPress}>
+    {selected ? 'This is selected' : 'This is not selected'}
+  </Text>
+);
+
+const renderSelectable = (): RenderAPI =>
+  render(
+    <Selectable mode={given.mode} onPress={given.onPress}>
+      <TestElement testID="1" selected={false} />
+      <TestElement testID="2" selected={true} />
+    </Selectable>,
+  );
+
+describe('Selectable', () => {
+  const onPress = jest.fn();
+
+  beforeEach(() => {
+    onPress.mockClear();
+  });
+
+  context('when "checkbox" is provided for mode', () => {
+    given('mode', () => 'checkbox' as Mode);
+
+    it('makes each child selectable', () => {
+      const {getByTestId} = renderSelectable();
+
+      expect(getByTestId('1')).toHaveTextContent('This is not selected');
+      expect(getByTestId('2')).toHaveTextContent('This is selected');
+
+      fireEvent.press(getByTestId('2'));
+
+      expect(getByTestId('1')).toHaveTextContent('This is not selected');
+      expect(getByTestId('2')).toHaveTextContent('This is not selected');
+
+      fireEvent.press(getByTestId('1'));
+
+      expect(getByTestId('1')).toHaveTextContent('This is selected');
+      expect(getByTestId('2')).toHaveTextContent('This is not selected');
+    });
+
+    context('when onPress is provided', () => {
+      given('onPress', () => onPress);
+
+      it('calls press handler with selected array', () => {
+        const {getByTestId} = renderSelectable();
+
+        fireEvent.press(getByTestId('1'));
+
+        expect(onPress).toBeCalledWith([true, true]);
+      });
+    });
+  });
+
+  context('when "singleChoice" is provided for mode', () => {
+    given('mode', () => 'singleChoice' as Mode);
+
+    it('allows one child to be selected', () => {
+      const {getByTestId} = renderSelectable();
+
+      expect(getByTestId('1')).toHaveTextContent('This is not selected');
+      expect(getByTestId('2')).toHaveTextContent('This is selected');
+
+      fireEvent.press(getByTestId('1'));
+
+      expect(getByTestId('1')).toHaveTextContent('This is selected');
+      expect(getByTestId('2')).toHaveTextContent('This is not selected');
+    });
+
+    context('when onPress is provided', () => {
+      given('onPress', () => onPress);
+
+      it('calls press handler with selected index', () => {
+        const {getByTestId} = renderSelectable();
+
+        fireEvent.press(getByTestId('1'));
+
+        expect(onPress).toBeCalledWith(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Introducing initial version of `[Selectable]`.

## Description
Inspired by  [react-router implementation](https://github.com/remix-run/react-router/blob/main/packages/react-router/modules/Switch.js)  and [Enumerable mixin](https://ruby-doc.org/core-3.0.2/Enumerable.html) in Ruby.

Designed to abstract selection of elements. 
Any component that has `onPress` and `selected` can take advantage of this abstraction.

Currently only component that has `onPress` and `selected` is supported, but others can be supported later. 
(Possible usage : "select all" button. It doesn't need `selected`.)

Here's some basic example.
 (providing **initial** `selected` for each item is also possible although It is not shown in example here.)

```ts
const [testString, setTestString] = useState('');

<Selectable
  mode="checkbox"
  onPress={(data) => setTestString(data.toString())}>
  <RadioButton label={testString} />
  <RadioButton label={testString} />
  <RadioButton label={testString} />
</Selectable>
```
![ezgif com-gif-maker](https://user-images.githubusercontent.com/61503739/129531390-e84b88cc-6671-4de1-af2c-a57f3845dbd5.gif)

```ts
const [testString, setTestString] = useState('');

<Selectable
  mode="singleChoice"
  onPress={(data) => setTestString(data.toString())}>
    {[1, 2, 3].map((key) => (
      <RadioButton key={key} label={testString} />
    ))}
</Selectable>
```
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/61503739/129531397-141b1bdb-38b9-4a86-8e9d-b68cbbfa916e.gif)

## Related Issues
none.

## Tests
Fully tested.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.

## Etc
- `toHaveTextContent` is imported and never used. It is still there because linter said there's no `toHaveTextContent` matcher. (which is not true.) I will to my best to remove it soon.
- `[Selectable]`'s props is not typed yet. Because there's some type warning problem related to `cloneElement`. I failed to solve it for now. So need some help.
- **There's lot to enhance [Selectable] and I didn't implement them yet.  Please share your thoughts.**

