### PR TITLE
Add display maxLength to EditText

### DIFF
--- a/main/EditText.tsx
+++ b/main/EditText.tsx
@@ -18,6 +18,7 @@ type Styles = {
   labelTextHovered?: StyleProp<TextStyle>;
   input?: StyleProp<TextStyle>;
   errorText?: StyleProp<TextStyle>;
+  counter?: StyleProp<TextStyle>;
 };
 
 export type EditTextProps = {
@@ -40,6 +41,7 @@ export type EditTextProps = {
   autoCapitalize?: TextInputProps['autoCapitalize'];
   secureTextEntry?: TextInputProps['secureTextEntry'];
   onSubmitEditing?: TextInputProps['onSubmitEditing'];
+
   focusColor?: string;
   hoverColor?: string;
   errorColor?: string;
@@ -136,6 +138,15 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
             },
             styles?.errorText,
           ],
+          counter: [
+            {
+              paddingHorizontal: 8,
+              paddingVertical: 10,
+              fontSize: 12,
+              color: !editable ? disableColor : textColor,
+            },
+            styles?.counter,
+          ],
         }
       : type === 'row'
       ? {
@@ -188,6 +199,14 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
               color: errorColor,
             },
             styles?.errorText,
+          ],
+          counter: [
+            {
+              marginTop: 4,
+              fontSize: 12,
+              color: !editable ? disableColor : textColor,
+            },
+            styles?.counter,
           ],
         }
       : {
@@ -330,14 +349,25 @@ const Component: FC<EditTextProps & {theme: DoobooTheme}> = ({
         />
       </View>
       {editable ? (
-        <Text
-          style={[
-            compositeStyles.errorText,
-            styles?.errorText,
-            {color: errorColor},
-          ]}>
-          {errorText}
-        </Text>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}>
+          <Text
+            style={[compositeStyles.errorText, {flex: 1, color: errorColor}]}>
+            {errorText}
+          </Text>
+          {textInputProps?.maxLength && (
+            <Text
+              style={
+                value.length < textInputProps.maxLength
+                  ? compositeStyles.counter
+                  : [compositeStyles.errorText, {color: errorColor}]
+              }>{`${value.length}/${textInputProps.maxLength}`}</Text>
+          )}
+        </View>
       ) : null}
     </View>
   );

--- a/main/__tests__/EditText.test.tsx
+++ b/main/__tests__/EditText.test.tsx
@@ -4,7 +4,6 @@ import {RenderAPI, act, fireEvent, render} from '@testing-library/react-native';
 import {EditText} from '../../main';
 import type {EditTextProps} from '../../main/EditText';
 import RNWebHooks from 'react-native-web-hooks';
-import {ReactTestInstance} from 'react-test-renderer';
 import {View} from 'react-native';
 import {createComponent} from '../../test/testUtils';
 
@@ -30,8 +29,6 @@ describe('[EditText]', () => {
     });
 
     describe('hovered', () => {
-      let container: ReactTestInstance;
-
       beforeAll(() => {
         jest.spyOn(RNWebHooks, 'useHover').mockImplementation(() => true);
       });
@@ -47,11 +44,12 @@ describe('[EditText]', () => {
           }),
         );
 
-        container = testingLib.getByTestId('container-id');
+        const container = testingLib.getByTestId('container-id');
+
         jest.runAllTimers();
 
         const containerChildViewCustomStyle =
-          container.findByType(View).instance.props.style[1][1];
+          container.findAllByType(View)[0].instance.props.style[1][1];
 
         expect(containerChildViewCustomStyle).toEqual({
           backgroundColor: 'green',
@@ -227,11 +225,53 @@ describe('[EditText]', () => {
               input: {},
               labelText: {},
               labelTextHovered: {},
+              counter: {},
             },
           }),
         );
 
         const json = testingLib.toJSON();
+
+        expect(json).toMatchSnapshot();
+        expect(json).toBeTruthy();
+      });
+
+      it('should render `maxLength` counter', () => {
+        testingLib = render(component());
+
+        const json = testingLib.toJSON();
+
+        expect(json).toBeTruthy();
+
+        testingLib = render(
+          component({
+            type: 'column',
+            textInputProps: {
+              maxLength: 10,
+            },
+          }),
+        );
+
+        expect(json).toMatchSnapshot();
+        expect(json).toBeTruthy();
+      });
+
+      it('should render `maxLength` counter with error style', () => {
+        testingLib = render(component());
+
+        const json = testingLib.toJSON();
+
+        expect(json).toBeTruthy();
+
+        testingLib = render(
+          component({
+            type: 'column',
+            textInputProps: {
+              maxLength: 10,
+            },
+            value: '0123456789',
+          }),
+        );
 
         expect(json).toMatchSnapshot();
         expect(json).toBeTruthy();
@@ -291,6 +331,26 @@ describe('[EditText]', () => {
         expect(json).toMatchSnapshot();
         expect(json).toBeTruthy();
       });
+
+      it('should render `maxLength` counter', () => {
+        testingLib = render(component());
+
+        const json = testingLib.toJSON();
+
+        expect(json).toBeTruthy();
+
+        testingLib = render(
+          component({
+            type: 'boxed',
+            textInputProps: {
+              maxLength: 10,
+            },
+          }),
+        );
+
+        expect(json).toMatchSnapshot();
+        expect(json).toBeTruthy();
+      });
     });
 
     describe('Type: [row]', () => {
@@ -340,6 +400,26 @@ describe('[EditText]', () => {
           component({
             type: 'row',
             editable: false,
+          }),
+        );
+
+        expect(json).toMatchSnapshot();
+        expect(json).toBeTruthy();
+      });
+
+      it('should render `maxLength` counter', () => {
+        testingLib = render(component());
+
+        const json = testingLib.toJSON();
+
+        expect(json).toBeTruthy();
+
+        testingLib = render(
+          component({
+            type: 'row',
+            textInputProps: {
+              maxLength: 10,
+            },
           }),
         );
 

--- a/main/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/main/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -305,27 +305,37 @@ exports[`[EditText] interactions Type: [boxed] should render \`!editable\` statu
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          undefined,
-        ],
-        undefined,
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -393,27 +403,135 @@ exports[`[EditText] interactions Type: [boxed] should render \`errorText\` 1`] =
       value=""
     />
   </View>
-  <Text
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`[EditText] interactions Type: [boxed] should render \`maxLength\` counter 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignSelf": "stretch",
+        "flexDirection": "column",
+      },
+      undefined,
+    ]
+  }
+  testID="container-id"
+>
+  <View
     style={
       Array [
         Array [
           Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
+            "alignSelf": "stretch",
+            "borderBottomColor": "black",
+            "borderBottomWidth": 1,
+            "flexDirection": "column",
+            "justifyContent": "space-between",
           },
           undefined,
         ],
-        undefined,
+        false,
         Object {
-          "color": "#FF002E",
+          "borderColor": "black",
+        },
+        Object {
+          "borderBottomColor": "black",
         },
       ]
     }
   >
-    
-  </Text>
+    <TextInput
+      allowFontScaling={true}
+      autoCapitalize="none"
+      editable={true}
+      multiline={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      placeholderTextColor="#6D6D6D"
+      rejectResponderTermination={true}
+      secureTextEntry={false}
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+              "paddingHorizontal": 10,
+              "paddingVertical": 10,
+            },
+            undefined,
+          ],
+          false,
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value=""
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -481,27 +599,37 @@ exports[`[EditText] interactions Type: [boxed] should render without crashing 1`
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          undefined,
-        ],
-        undefined,
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -569,27 +697,37 @@ exports[`[EditText] interactions Type: [column] - default renders custom styles 
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          Object {},
-        ],
-        Object {},
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            Object {},
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -657,27 +795,233 @@ exports[`[EditText] interactions Type: [column] - default renders without crashi
       value=""
     />
   </View>
-  <Text
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`[EditText] interactions Type: [column] - default should render \`maxLength\` counter 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignSelf": "stretch",
+        "flexDirection": "column",
+      },
+      undefined,
+    ]
+  }
+  testID="container-id"
+>
+  <View
     style={
       Array [
         Array [
           Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
+            "alignSelf": "stretch",
+            "borderBottomColor": "black",
+            "borderBottomWidth": 1,
+            "flexDirection": "column",
+            "justifyContent": "space-between",
           },
           undefined,
         ],
-        undefined,
+        false,
         Object {
-          "color": "#FF002E",
+          "borderColor": "black",
+        },
+        Object {
+          "borderBottomColor": "black",
         },
       ]
     }
   >
-    
-  </Text>
+    <TextInput
+      allowFontScaling={true}
+      autoCapitalize="none"
+      editable={true}
+      multiline={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      placeholderTextColor="#6D6D6D"
+      rejectResponderTermination={true}
+      secureTextEntry={false}
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+              "paddingHorizontal": 10,
+              "paddingVertical": 10,
+            },
+            undefined,
+          ],
+          false,
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value=""
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`[EditText] interactions Type: [column] - default should render \`maxLength\` counter with error style 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignSelf": "stretch",
+        "flexDirection": "column",
+      },
+      undefined,
+    ]
+  }
+  testID="container-id"
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "borderBottomColor": "black",
+            "borderBottomWidth": 1,
+            "flexDirection": "column",
+            "justifyContent": "space-between",
+          },
+          undefined,
+        ],
+        false,
+        Object {
+          "borderColor": "black",
+        },
+        Object {
+          "borderBottomColor": "black",
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      autoCapitalize="none"
+      editable={true}
+      multiline={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      placeholderTextColor="#6D6D6D"
+      rejectResponderTermination={true}
+      secureTextEntry={false}
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+              "paddingHorizontal": 10,
+              "paddingVertical": 10,
+            },
+            undefined,
+          ],
+          false,
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value=""
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -745,27 +1089,37 @@ exports[`[EditText] interactions Type: [row] should render \`!editable\` status 
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          undefined,
-        ],
-        undefined,
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -833,27 +1187,135 @@ exports[`[EditText] interactions Type: [row] should render \`errorText\` 1`] = `
       value=""
     />
   </View>
-  <Text
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`[EditText] interactions Type: [row] should render \`maxLength\` counter 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignSelf": "stretch",
+        "flexDirection": "column",
+      },
+      undefined,
+    ]
+  }
+  testID="container-id"
+>
+  <View
     style={
       Array [
         Array [
           Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
+            "alignSelf": "stretch",
+            "borderBottomColor": "black",
+            "borderBottomWidth": 1,
+            "flexDirection": "column",
+            "justifyContent": "space-between",
           },
           undefined,
         ],
-        undefined,
+        false,
         Object {
-          "color": "#FF002E",
+          "borderColor": "black",
+        },
+        Object {
+          "borderBottomColor": "black",
         },
       ]
     }
   >
-    
-  </Text>
+    <TextInput
+      allowFontScaling={true}
+      autoCapitalize="none"
+      editable={true}
+      multiline={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      placeholderTextColor="#6D6D6D"
+      rejectResponderTermination={true}
+      secureTextEntry={false}
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+              "paddingHorizontal": 10,
+              "paddingVertical": 10,
+            },
+            undefined,
+          ],
+          false,
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value=""
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -921,27 +1383,37 @@ exports[`[EditText] interactions Type: [row] should render without crashing 1`] 
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          undefined,
-        ],
-        undefined,
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;
 
@@ -1011,26 +1483,36 @@ exports[`[EditText] interactions web renders without crashing 1`] = `
       value=""
     />
   </View>
-  <Text
+  <View
     style={
-      Array [
-        Array [
-          Object {
-            "color": "#FF002E",
-            "fontSize": 12,
-            "marginTop": 8,
-            "paddingHorizontal": 10,
-          },
-          undefined,
-        ],
-        undefined,
-        Object {
-          "color": "#FF002E",
-        },
-      ]
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+      }
     }
   >
-    
-  </Text>
+    <Text
+      style={
+        Array [
+          Array [
+            Object {
+              "color": "#FF002E",
+              "fontSize": 12,
+              "marginTop": 8,
+              "paddingHorizontal": 10,
+            },
+            undefined,
+          ],
+          Object {
+            "color": "#FF002E",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
 </View>
 `;

--- a/stories/dooboo-ui/EditTextStories/EditTextColumnStory.tsx
+++ b/stories/dooboo-ui/EditTextStories/EditTextColumnStory.tsx
@@ -39,6 +39,18 @@ const EditTextColumn = (): React.ReactElement => {
         />
         <EditText
           type="column"
+          labelText="label"
+          placeholder="EditText with label and maxLength"
+          value={password}
+          onChangeText={(text) => onTextChanged('PASSWORD', text)}
+          style={{marginTop: 20, marginBottom: 24, paddingHorizontal: 36}}
+          textInputProps={{
+            multiline: true,
+            maxLength: 10,
+          }}
+        />
+        <EditText
+          type="column"
           labelText="disabled"
           value="Disabled EditText"
           editable={false}


### PR DESCRIPTION
## Description

Current EditText component has no way to display `maxLength` prop of RN's `TextInput` component.
So I added that feature.

## Related Issues

N/A

## Tests

I added the following tests:

1. props with maxLength 
2. props with maxLength and when `value.length >= maxLength`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
