### PR TITLE
Rewrite SwitchToggle

### DIFF
--- a/docs/src/components/SwitchToggle/Basic.tsx
+++ b/docs/src/components/SwitchToggle/Basic.tsx
@@ -1,0 +1,31 @@
+import {FC, useState} from 'react';
+import {SwitchToggle, ThemeProvider, ThemeType, Typography} from 'dooboo-ui';
+
+import {View} from 'react-native';
+
+export const Basic: FC<{themeType: ThemeType}> = ({themeType}) => {
+  const [isOn, setIsOn] = useState(false);
+
+  return (
+    <ThemeProvider initialThemeType={themeType}>
+      <View
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <View style={{flexDirection: 'row', alignItems: 'center'}}>
+          <Typography.Body1>{isOn ? 'On' : 'Off'}</Typography.Body1>
+          <SwitchToggle isOn={isOn} onPress={() => setIsOn(!isOn)} />
+        </View>
+        <View style={{flexDirection: 'row', alignItems: 'center'}}>
+          <Typography.Body1>{!isOn ? 'On' : 'Off'}</Typography.Body1>
+          <SwitchToggle
+            style={{transform: [{rotate: '180deg'}]}}
+            isOn={!isOn}
+            onPress={() => setIsOn(!isOn)}
+          />
+        </View>
+      </View>
+    </ThemeProvider>
+  );
+};

--- a/docs/src/components/SwitchToggle/SwitchToggle.stories.mdx
+++ b/docs/src/components/SwitchToggle/SwitchToggle.stories.mdx
@@ -1,0 +1,57 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks';
+import {Basic }from './index'
+
+<Meta title="Components/SwitchToggle" />
+
+# SwitchToggle
+
+> Simple SwitchToggle with animation for react-native.<br/>
+
+## Props
+
+|                 | necessary | types                   | Description   | default               |
+| --------------- | --------- | ----------------------- | ------------- | --------------------- |
+| testID          |           | `string`                |               | `undefined`           |
+| isOn            |     ✓     | `boolean`               |               |                       |
+| theme           |           | `DoobooTheme`           |               | `light`               |
+| style           |           | `styleProp<ViewStyle>`  |               | `undefined`           |
+| styles          |           | `Styles`                |               | `defaultContainerStyle, defaultCircleStyle `               |
+| duration        |           | `number`                |               | `300`                 |
+| onElement       |           | `React.ReactElement`    |               | `undefined`           |
+| offElement      |           | `React.ReactElement`    |               | `undefined`           |
+| onPress         |           | `() => void`            |               | `undefined`           |
+
+
+```typescript
+interface Styles {
+  containerStyle?: ViewStyle;
+  onElementContainerStyle?: StyleProp<ViewStyle>;
+  offElementContainerStyle?: StyleProp<ViewStyle>;
+  circleStyle?: ViewStyle;
+  buttonStyle?: StyleProp<ViewStyle>;
+  circleColorOff?: string;
+  circleColorOn?: string;
+  backgroundColorOn?: string;
+  backgroundColorOff?: string;
+}
+
+const defaultContainerStyle: ViewStyle = {
+  width: 80,
+  height: 40,
+  borderRadius: 25,
+  padding: 5,
+};
+
+const defaultCircleStyle: ViewStyle = {
+  width: 32,
+  height: 32,
+  borderRadius: 16,
+};
+```
+
+## Demo
+
+### Basic Style
+<Basic/>
+
+

--- a/docs/src/components/SwitchToggle/index.tsx
+++ b/docs/src/components/SwitchToggle/index.tsx
@@ -1,0 +1,1 @@
+export * from './Basic';

--- a/docs/src/contributing/contributing.stories.mdx
+++ b/docs/src/contributing/contributing.stories.mdx
@@ -99,7 +99,7 @@ Generally, each PR should contain one commit that is amended as you address code
 ### Coding Guidelines
 
 We follow [dooboolab coding principle 2021](https://medium.com/dooboolab/dooboolab-coding-principle-2021-c809d112b18d) when writing code for `dooboo-ui`.
-There are few others to be considered specific to `dooboo-ui`.
+There are also few others to be considered specific to `dooboo-ui`.
 
 1. Never expose `single` attributes in style props.
 
@@ -191,7 +191,7 @@ There are few others to be considered specific to `dooboo-ui`.
 #### Tips
 
 Try to write specification for ui component before writing code. How would you want yourself to use the component?
-For example, does below looks great? Any more thing you think you would need?
+For example, does below looks great? Anything more you think would be needed?
 
 ```tsx
 <EditText
@@ -203,7 +203,7 @@ For example, does below looks great? Any more thing you think you would need?
 />
 ```
 
-If you want to discuss on your proposal please feel free to open up anything in [discussions](https://github.com/dooboolab/dooboo-ui/discussions).
+> If you want to discuss on your proposal please feel free to open up anything in [discussions](https://github.com/dooboolab/dooboo-ui/discussions).
 
 #### Naming conventions
 

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -95,7 +95,8 @@ function Component(props: Props): React.ReactElement {
   const circlePosXEnd =
     ((containerStyle.width ?? defaultContainerStyle.width) as number) -
     ((circleStyle.width ?? defaultCircleStyle.width) as number) -
-    paddingRight * 2;
+    paddingRight -
+    paddingLeft;
 
   const [animXValue] = useState(new Animated.Value(isOn ? 1 : 0));
 

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -1,151 +1,180 @@
-import {
-  Animated,
-  StyleProp,
-  Text,
-  TextStyle,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from 'react-native';
+import {Animated, StyleProp, TouchableOpacity, ViewStyle} from 'react-native';
 import {DoobooTheme, light} from './theme';
-import React, {useEffect, useRef, useState} from 'react';
+import {ReactElement, useEffect, useState} from 'react';
 
 import styled from '@emotion/native';
 import {withTheme} from '@emotion/react';
 
-interface Props {
-  testID?: string;
-  theme?: DoobooTheme;
-  switchOn: boolean;
-  onPress: () => void;
+interface Styles {
   containerStyle?: ViewStyle;
+  onElementContainerStyle?: StyleProp<ViewStyle>;
+  offElementContainerStyle?: StyleProp<ViewStyle>;
   circleStyle?: ViewStyle;
-  backgroundColorOn?: string;
-  backgroundColorOff?: string;
-  backgroundImageOn?: React.ReactElement;
-  backgroundImageOff?: React.ReactElement;
+  buttonStyle?: StyleProp<ViewStyle>;
   circleColorOff?: string;
   circleColorOn?: string;
-  duration?: number;
-  type?: number;
-  buttonText?: string;
-  backTextRight?: string;
-  backTextLeft?: string;
-  buttonTextStyle?: StyleProp<TextStyle>;
-  textRightStyle?: StyleProp<TextStyle>;
-  textLeftStyle?: StyleProp<TextStyle>;
-  buttonStyle?: StyleProp<ViewStyle>;
-  // limitation: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/12202
-  buttonContainerStyle?: StyleProp<ViewStyle>;
-  rightContainerStyle?: StyleProp<ViewStyle>;
-  leftContainerStyle?: StyleProp<ViewStyle>;
-  RTL?: boolean;
+  backgroundColorOn?: string;
+  backgroundColorOff?: string;
 }
+
+interface Props {
+  testID?: string;
+  isOn: boolean;
+  theme?: DoobooTheme;
+  style?: StyleProp<ViewStyle>;
+  styles?: Styles;
+  duration?: number;
+  onElement?: ReactElement;
+  offElement?: ReactElement;
+  onPress?: () => void;
+}
+
+// Typing limitation: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/12202
 
 const AnimatedContainer = styled(Animated.View)`
   flex-direction: row;
   align-items: center;
 `;
 
+const defaultContainerStyle: ViewStyle = {
+  width: 80,
+  height: 40,
+  borderRadius: 25,
+  padding: 5,
+};
+
+const defaultCircleStyle: ViewStyle = {
+  width: 32,
+  height: 32,
+  borderRadius: 16,
+};
+
 function Component(props: Props): React.ReactElement {
   const {
+    testID,
+    isOn = false,
+    theme = light,
+    style,
+    styles,
     duration = 300,
-    backgroundImageOn,
-    backgroundImageOff,
-    backgroundColorOn,
-    backgroundColorOff,
-    circleColorOn,
-    circleColorOff,
-    containerStyle,
+    onElement,
+    offElement,
+    onPress,
   } = props;
 
-  const padding: number =
-    (containerStyle?.padding as number) ||
-    (containerStyle?.paddingLeft as number) ||
+  const {primary, disabled, textContrast, placeholder} = theme;
+
+  const {
+    backgroundColorOn = primary,
+    backgroundColorOff = disabled,
+    circleColorOn = textContrast,
+    circleColorOff = placeholder,
+    containerStyle = defaultContainerStyle,
+    circleStyle = defaultCircleStyle,
+    buttonStyle,
+    onElementContainerStyle,
+    offElementContainerStyle,
+  } = styles ?? {};
+
+  const paddingLeft: number =
+    (containerStyle.padding as number) ||
+    (containerStyle.paddingLeft as number) ||
     0;
 
-  const [animXValue] = useState(new Animated.Value(props.switchOn ? 1 : 0));
+  const paddingRight: number =
+    (containerStyle.padding as number) ||
+    (containerStyle.paddingRight as number) ||
+    0;
 
-  const getStart = (): number | Record<string, unknown> | undefined => {
-    return props.type === undefined
-      ? 0
-      : props.type === 0
-      ? 0
-      : padding
-      ? padding * 2
-      : {};
-  };
+  const circlePosXStart = 0;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const runAnimation = (): void => {
-    const animValue = {
-      fromValue: props.switchOn ? 0 : 1,
-      toValue: props.switchOn ? 1 : 0,
-      duration,
-      useNativeDriver: false,
-    };
+  const circlePosXEnd =
+    (containerStyle.width as number) -
+    (circleStyle.width as number) -
+    paddingRight * 2;
 
-    Animated.timing(animXValue, animValue).start();
-  };
-
-  const endPos =
-    props.containerStyle && props.circleStyle
-      ? (props.containerStyle.width as number) -
-        ((props.circleStyle.width as number) +
-          ((props.containerStyle?.paddingRight as number) || padding || 0) * 2)
-      : 0;
-
-  const circlePosXEnd = props.RTL ? -endPos : endPos;
-  const [circlePosXStart] = useState(getStart());
-
-  const prevSwitchOnRef = useRef<boolean>();
-  const prevSwitchOn = !!prevSwitchOnRef.current;
+  const [animXValue] = useState(new Animated.Value(isOn ? 1 : 0));
 
   useEffect(() => {
-    prevSwitchOnRef.current = props.switchOn;
+    const runAnimation = (): void => {
+      const option = {
+        fromValue: isOn ? 0 : 1,
+        toValue: isOn ? 1 : 0,
+        duration,
+        useNativeDriver: false,
+      };
 
-    if (prevSwitchOn !== props.switchOn) runAnimation();
-  }, [prevSwitchOn, props.switchOn, runAnimation]);
+      Animated.timing(animXValue, option).start();
+    };
 
-  const generateRightText = (): React.ReactElement => {
-    return (
-      <Animated.View style={props.rightContainerStyle}>
-        <Text style={props.textRightStyle}>{props.backTextRight}</Text>
-      </Animated.View>
-    );
-  };
+    runAnimation();
+  }, [animXValue, isOn, duration]);
 
-  const generateLeftText = (): React.ReactElement => {
-    return (
-      <Animated.View style={props.leftContainerStyle}>
-        <Text style={props.textLeftStyle}>{props.backTextLeft}</Text>
-      </Animated.View>
-    );
-  };
+  const CircleButton = (
+    <Animated.View
+      style={[
+        circleStyle,
+        {
+          backgroundColor: animXValue.interpolate({
+            inputRange: [0.5, 1],
+            outputRange: [
+              circleColorOff as string | number,
+              circleColorOn as string | number,
+            ] as string[] | number[],
+          }),
+        },
+        {
+          transform: [
+            {
+              translateX: animXValue.interpolate({
+                inputRange: [0, 1],
+                outputRange: [
+                  circlePosXStart as string | number,
+                  circlePosXEnd as string | number,
+                ] as string[] | number[],
+              }),
+            },
+          ],
+        },
+        buttonStyle,
+      ]}
+    />
+  );
 
-  const generateLeftIcon = (): React.ReactElement => {
-    return (
-      <View style={{position: 'absolute', left: 5}}>{backgroundImageOn}</View>
-    );
-  };
+  const OnElement = (
+    <Animated.View style={[{opacity: animXValue}, onElementContainerStyle]}>
+      {onElement}
+    </Animated.View>
+  );
 
-  const generateRightIcon = (): React.ReactElement => {
-    return (
-      <View style={{position: 'absolute', right: 5}}>{backgroundImageOff}</View>
-    );
-  };
+  const OffElement = (
+    <Animated.View
+      style={[
+        {
+          opacity: animXValue.interpolate({
+            inputRange: [0, 1],
+            outputRange: [1, 0],
+          }),
+        },
+        offElementContainerStyle,
+      ]}>
+      {offElement}
+    </Animated.View>
+  );
 
   return (
     <TouchableOpacity
-      testID={props.testID}
-      onPress={props.onPress}
+      testID={testID}
+      accessibilityRole="switch"
+      style={style}
+      onPress={onPress}
       activeOpacity={0.8}>
       <AnimatedContainer
         style={[
-          props.containerStyle,
+          containerStyle,
           {
-            paddingLeft: props.containerStyle?.paddingLeft || padding,
-            paddingRight: props.containerStyle?.paddingRight || padding,
+            paddingLeft,
+            paddingRight,
           },
           {
             backgroundColor: animXValue.interpolate({
@@ -157,64 +186,11 @@ function Component(props: Props): React.ReactElement {
             }),
           },
         ]}>
-        {generateLeftText()}
-        {props.switchOn && generateLeftIcon()}
-        <Animated.View
-          style={[
-            props.circleStyle,
-            {
-              backgroundColor: animXValue.interpolate({
-                inputRange: [0.5, 1],
-                outputRange: [
-                  circleColorOff as string | number,
-                  circleColorOn as string | number,
-                ] as string[] | number[],
-              }),
-            },
-            {
-              transform: [
-                {
-                  translateX: animXValue.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [
-                      circlePosXStart as string | number,
-                      circlePosXEnd as string | number,
-                    ] as string[] | number[],
-                  }),
-                },
-              ],
-            },
-            props.buttonStyle,
-          ]}>
-          <Animated.View style={props.buttonContainerStyle}>
-            <Text style={props.buttonTextStyle}>{props.buttonText}</Text>
-          </Animated.View>
-        </Animated.View>
-        {generateRightText()}
-        {!props.switchOn && generateRightIcon()}
+        {isOn ? OnElement : OffElement}
+        {CircleButton}
       </AnimatedContainer>
     </TouchableOpacity>
   );
 }
-
-Component.defaultProps = {
-  theme: light,
-  backgroundColorOn: light.primary,
-  backgroundColorOff: light.disabled,
-  circleColorOn: light.textContrast,
-  circleColorOff: light.placeholder,
-  containerStyle: {
-    marginTop: 16,
-    width: 80,
-    height: 40,
-    borderRadius: 25,
-    padding: 5,
-  },
-  circleStyle: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-  },
-};
 
 export const SwitchToggle = withTheme(Component);

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -5,6 +5,8 @@ import {ReactElement, useEffect, useState} from 'react';
 import styled from '@emotion/native';
 import {withTheme} from '@emotion/react';
 
+import {isEmptyObject} from './utils';
+
 interface Styles {
   containerStyle?: ViewStyle;
   onElementContainerStyle?: StyleProp<ViewStyle>;
@@ -53,7 +55,6 @@ function Component(props: Props): React.ReactElement {
   const {
     testID,
     isOn,
-    theme = light,
     style,
     styles,
     duration = 300,
@@ -61,6 +62,9 @@ function Component(props: Props): React.ReactElement {
     offElement,
     onPress,
   } = props;
+
+  const theme =
+    !props.theme || isEmptyObject(props.theme) ? light : props.theme;
 
   const {primary, disabled, textContrast, placeholder} = theme;
 

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -89,8 +89,8 @@ function Component(props: Props): React.ReactElement {
   const circlePosXStart = 0;
 
   const circlePosXEnd =
-    ((containerStyle.width as number) ?? defaultContainerStyle.width) -
-    ((circleStyle.width as number) ?? defaultCircleStyle.width) -
+    ((containerStyle.width ?? defaultContainerStyle.width) as number) -
+    ((circleStyle.width ?? defaultCircleStyle.width) as number) -
     paddingRight * 2;
 
   const [animXValue] = useState(new Animated.Value(isOn ? 1 : 0));

--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -52,7 +52,7 @@ const defaultCircleStyle: ViewStyle = {
 function Component(props: Props): React.ReactElement {
   const {
     testID,
-    isOn = false,
+    isOn,
     theme = light,
     style,
     styles,
@@ -89,8 +89,8 @@ function Component(props: Props): React.ReactElement {
   const circlePosXStart = 0;
 
   const circlePosXEnd =
-    (containerStyle.width as number) -
-    (circleStyle.width as number) -
+    ((containerStyle.width as number) ?? defaultContainerStyle.width) -
+    ((circleStyle.width as number) ?? defaultCircleStyle.width) -
     paddingRight * 2;
 
   const [animXValue] = useState(new Animated.Value(isOn ? 1 : 0));

--- a/main/__tests__/SwitchToggle.test.tsx
+++ b/main/__tests__/SwitchToggle.test.tsx
@@ -1,296 +1,64 @@
 import React, {ReactElement} from 'react';
+import {fireEvent, render} from '@testing-library/react-native';
 
 import {SwitchToggle} from '../SwitchToggle';
-import {TouchableOpacity} from 'react-native';
+import {Text} from 'react-native';
+import {createComponent} from '../../test/testUtils';
 import renderer from 'react-test-renderer';
 
-const createTestProps = (
-  obj?: Record<string, unknown>,
-): Record<string, unknown> => ({
-  ...obj,
-});
+describe('[SwitchToggle]', () => {
+  const handlePress = jest.fn();
 
-let props;
-let component: ReactElement;
-
-describe('[SwitchToggle]', (): void => {
-  props = createTestProps({
-    testID: 'SWITCH_ID',
-    onPress: jest.fn(),
+  beforeEach(() => {
+    handlePress.mockClear();
   });
 
-  component = <SwitchToggle {...props} />;
+  it('handles press event', () => {
+    const {getByA11yRole} = render(
+      <SwitchToggle isOn={false} onPress={handlePress} />,
+    );
 
-  describe('Rendering', () => {
-    it('should render without crashing', () => {
-      const rendered = renderer.create(component);
+    fireEvent.press(getByA11yRole('switch'));
+    expect(handlePress).toBeCalled();
+  });
 
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
+  const getSwitchToggle = ({isOn}: {isOn: boolean}): ReactElement =>
+    createComponent(
+      <SwitchToggle
+        isOn={isOn}
+        onPress={handlePress}
+        onElement={<Text>on</Text>}
+        offElement={<Text>off</Text>}
+        style={{padding: 6}}
+        styles={{
+          containerStyle: {padding: 5},
+          onElementContainerStyle: {padding: 4},
+          offElementContainerStyle: {padding: 3},
+          circleStyle: {padding: 2},
+          buttonStyle: {padding: 1},
+          circleColorOff: 'red',
+          circleColorOn: 'blue',
+          backgroundColorOn: 'green',
+          backgroundColorOff: 'grey',
+        }}
+      />,
+    );
 
-    it('should render type === 0', () => {
-      props = {
-        ...props,
-        type: 0,
-      };
+  context('when switch toggle is on', () => {
+    it('renders as on state', () => {
+      const component = renderer.create(getSwitchToggle({isOn: true})).toJSON();
 
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render `containerStyle` and `containerStyle.padding`', () => {
-      props = {
-        ...props,
-        type: 1,
-        containerStyle: {
-          padding: 40,
-        },
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render `containerStyle` and `circleWidth`', () => {
-      props = {
-        ...props,
-        type: 1,
-        containerStyle: {
-          padding: 40,
-          width: 40,
-        },
-        circleStyle: {
-          width: 20,
-        },
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render `containerStyle` and `circleWidth` without padding', () => {
-      props = {
-        ...props,
-        type: 1,
-        containerStyle: {
-          padding: 0,
-          width: 40,
-        },
-        circleStyle: {
-          width: 20,
-        },
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render when `containerStyle` is not defined', () => {
-      props = {
-        ...props,
-        type: 1,
-        containerStyle: undefined,
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render RTL', () => {
-      props = {
-        ...props,
-        type: 1,
-        RTL: true,
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
+      expect(component).toMatchSnapshot();
     });
   });
 
-  describe('Accessibility', (): void => {
-    it('should render AccessibilityLabel', () => {
-      props = {
-        ...props,
-        type: 1,
-        accessibilityLabel: 'Label for test accessibility',
-      };
+  context('when switch toggle is off', () => {
+    it('renders as off state', () => {
+      const component = renderer
+        .create(getSwitchToggle({isOn: false}))
+        .toJSON();
 
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render AccessibilityRole', () => {
-      props = {
-        ...props,
-        type: 1,
-        accessibilityRole: 'switch',
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render AccessibilityHint', () => {
-      props = {
-        ...props,
-        type: 1,
-        accessibilityHint: 'Accessibility hint can be a string or empty',
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render AccessibilityState', () => {
-      props = {
-        ...props,
-        type: 1,
-        accessibilityState: {
-          disabled: false,
-          selected: true,
-          checked: false,
-          busy: false,
-          expanded: false,
-        },
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-
-    it('should render AccessibilityValue', () => {
-      props = {
-        ...props,
-        type: 1,
-        accessibilityValue: {
-          min: 0,
-          max: 1,
-          now: 0,
-          text: 'optional text',
-        },
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-
-      expect(rendered).toMatchSnapshot();
-      expect(rendered).toBeTruthy();
-    });
-  });
-
-  it('should render custom `colors` and `duration`', () => {
-    props = {
-      ...props,
-      backgroundColorOn: 'red',
-      backgroundColorOff: 'red',
-      circleColorOn: 'red',
-      circleColorOff: 'red',
-      duration: 500,
-    };
-
-    component = <SwitchToggle {...props} />;
-
-    const rendered = renderer.create(component);
-
-    expect(rendered).toMatchSnapshot();
-    expect(rendered).toBeTruthy();
-  });
-
-  describe('Interaction', (): void => {
-    it('should simulate onPress', () => {
-      const rendered = renderer.create(component);
-      const switchToggle = rendered.root.findByType(TouchableOpacity);
-
-      switchToggle.props.onPress();
-
-      expect(props.onPress).toHaveBeenCalled();
-    });
-
-    it('should toggle switch on/off when pressed', () => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
-      const props = {
-        switchOn: false,
-        onPress: () => (props.switchOn = !props.switchOn),
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-      const switchToggle = rendered.root.findByType(TouchableOpacity);
-
-      expect(props.switchOn).toBeFalsy();
-
-      switchToggle.props.onPress();
-
-      expect(props.switchOn).toBeTruthy();
-
-      switchToggle.props.onPress();
-
-      expect(props.switchOn).toBeFalsy();
-    });
-
-    it('should toggle switchOn to `false` on pressed', () => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
-      const props = {
-        switchOn: true,
-        onPress: jest.fn(),
-      };
-
-      component = <SwitchToggle {...props} />;
-
-      const rendered = renderer.create(component);
-      const switchToggle = rendered.root.findByType(TouchableOpacity);
-
-      switchToggle.props.onPress();
-
-      expect(props.switchOn).toBeTruthy();
-
-      switchToggle.props.onPress();
-
-      expect(props.onPress).toHaveBeenCalled();
+      expect(component).toMatchSnapshot();
     });
   });
 });

--- a/main/__tests__/SwitchToggle.test.tsx
+++ b/main/__tests__/SwitchToggle.test.tsx
@@ -31,7 +31,7 @@ describe('[SwitchToggle]', () => {
         offElement={<Text>off</Text>}
         style={{padding: 6}}
         styles={{
-          containerStyle: {padding: 5},
+          containerStyle: {paddingLeft: 6, paddingRight: 5},
           onElementContainerStyle: {padding: 4},
           offElementContainerStyle: {padding: 3},
           circleStyle: {padding: 2},

--- a/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
+++ b/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`[SwitchToggle] when switch toggle is off renders as off state 1`] = `
           "padding": 1,
           "transform": Array [
             Object {
-              "translateX": NaN,
+              "translateX": 0,
             },
           ],
         }
@@ -110,7 +110,7 @@ exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
           "padding": 1,
           "transform": Array [
             Object {
-              "translateX": NaN,
+              "translateX": 38,
             },
           ],
         }

--- a/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
+++ b/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`[SwitchToggle] when switch toggle is off renders as off state 1`] = `
         "paddingRight": 5,
       }
     }
-    testID="container"
   >
     <View
       style={
@@ -56,7 +55,6 @@ exports[`[SwitchToggle] when switch toggle is off renders as off state 1`] = `
           ],
         }
       }
-      testID="circle"
     />
   </View>
 </View>
@@ -92,7 +90,6 @@ exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
         "paddingRight": 5,
       }
     }
-    testID="container"
   >
     <View
       style={
@@ -118,7 +115,6 @@ exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
           ],
         }
       }
-      testID="circle"
     />
   </View>
 </View>

--- a/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
+++ b/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
@@ -25,8 +25,7 @@ exports[`[SwitchToggle] when switch toggle is off renders as off state 1`] = `
         "alignItems": "center",
         "backgroundColor": "rgba(128, 128, 128, 1)",
         "flexDirection": "row",
-        "padding": 5,
-        "paddingLeft": 5,
+        "paddingLeft": 6,
         "paddingRight": 5,
       }
     }
@@ -85,8 +84,7 @@ exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
         "alignItems": "center",
         "backgroundColor": "rgba(0, 128, 0, 1)",
         "flexDirection": "row",
-        "padding": 5,
-        "paddingLeft": 5,
+        "paddingLeft": 6,
         "paddingRight": 5,
       }
     }
@@ -110,7 +108,7 @@ exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
           "padding": 1,
           "transform": Array [
             Object {
-              "translateX": 38,
+              "translateX": 37,
             },
           ],
         }

--- a/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
+++ b/main/__tests__/__snapshots__/SwitchToggle.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[SwitchToggle] Accessibility should render AccessibilityHint 1`] = `
+exports[`[SwitchToggle] when switch toggle is off renders as off state 1`] = `
 <View
+  accessibilityRole="switch"
   accessible={true}
   focusable={true}
   onClick={[Function]}
@@ -14,538 +15,56 @@ exports[`[SwitchToggle] Accessibility should render AccessibilityHint 1`] = `
   style={
     Object {
       "opacity": 1,
+      "padding": 6,
     }
   }
-  testID="SWITCH_ID"
 >
   <View
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
+        "backgroundColor": "rgba(128, 128, 128, 1)",
         "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
         "padding": 5,
         "paddingLeft": 5,
         "paddingRight": 5,
-        "width": 80,
       }
     }
+    testID="container"
   >
-    <View>
-      <Text />
-    </View>
     <View
       style={
         Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
+          "opacity": 1,
+          "padding": 3,
         }
       }
     >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
+      <Text>
+        off
+      </Text>
     </View>
     <View
       style={
         Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Accessibility should render AccessibilityLabel 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Accessibility should render AccessibilityRole 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Accessibility should render AccessibilityState 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Accessibility should render AccessibilityValue 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleWidth\` 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "flexDirection": "row",
-        "padding": 40,
-        "paddingLeft": 40,
-        "paddingRight": 40,
-        "width": 40,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 80,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`circleWidth\` without padding 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "flexDirection": "row",
-        "padding": 0,
-        "paddingLeft": 0,
-        "paddingRight": 0,
-        "width": 40,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": "NaN[object Object]",
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render \`containerStyle\` and \`containerStyle.padding\` 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "flexDirection": "row",
-        "padding": 40,
-        "paddingLeft": 40,
-        "paddingRight": 40,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "borderRadius": 16,
-          "height": 32,
+          "backgroundColor": "rgba(510, 0, -255, 1)",
+          "padding": 1,
           "transform": Array [
             Object {
               "translateX": NaN,
             },
           ],
-          "width": 32,
         }
       }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
+      testID="circle"
     />
   </View>
 </View>
 `;
 
-exports[`[SwitchToggle] Rendering should render RTL 1`] = `
+exports[`[SwitchToggle] when switch toggle is on renders as on state 1`] = `
 <View
+  accessibilityRole="switch"
   accessible={true}
   focusable={true}
   onClick={[Function]}
@@ -558,336 +77,48 @@ exports[`[SwitchToggle] Rendering should render RTL 1`] = `
   style={
     Object {
       "opacity": 1,
+      "padding": 6,
     }
   }
-  testID="SWITCH_ID"
 >
   <View
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
+        "backgroundColor": "rgba(0, 128, 0, 1)",
         "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
         "padding": 5,
         "paddingLeft": 5,
         "paddingRight": 5,
-        "width": 80,
       }
     }
+    testID="container"
   >
-    <View>
-      <Text />
-    </View>
     <View
       style={
         Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
+          "opacity": 1,
+          "padding": 4,
         }
       }
     >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
+      <Text>
+        on
+      </Text>
     </View>
     <View
       style={
         Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render type === 0 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "borderRadius": 16,
-          "height": 32,
+          "backgroundColor": "rgba(0, 0, 255, 1)",
+          "padding": 1,
           "transform": Array [
             Object {
-              "translateX": 0,
+              "translateX": NaN,
             },
           ],
-          "width": 32,
         }
       }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render when \`containerStyle\` is not defined 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] Rendering should render without crashing 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(196, 196, 196, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(-37, -37, -37, 1)",
-          "borderRadius": 16,
-          "height": 32,
-          "transform": Array [
-            Object {
-              "translateX": 0,
-            },
-          ],
-          "width": 32,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
-    />
-  </View>
-</View>
-`;
-
-exports[`[SwitchToggle] should render custom \`colors\` and \`duration\` 1`] = `
-<View
-  accessible={true}
-  focusable={true}
-  onClick={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
-  testID="SWITCH_ID"
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "rgba(255, 0, 0, 1)",
-        "borderRadius": 25,
-        "flexDirection": "row",
-        "height": 40,
-        "marginTop": 16,
-        "padding": 5,
-        "paddingLeft": 5,
-        "paddingRight": 5,
-        "width": 80,
-      }
-    }
-  >
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "backgroundColor": "rgba(255, 0, 0, 1)",
-          "transform": Array [
-            Object {
-              "translateX": 10,
-            },
-          ],
-          "width": 20,
-        }
-      }
-    >
-      <View>
-        <Text />
-      </View>
-    </View>
-    <View>
-      <Text />
-    </View>
-    <View
-      style={
-        Object {
-          "position": "absolute",
-          "right": 5,
-        }
-      }
+      testID="circle"
     />
   </View>
 </View>

--- a/main/utils.tsx
+++ b/main/utils.tsx
@@ -1,0 +1,4 @@
+export const isEmptyObject = (param: any): boolean =>
+  Object.keys(param).length === 0 && param.constructor === Object;
+
+export default {};

--- a/stories/dooboo-ui/SwitchToggleStories/SwitchToggleDefaultStory.tsx
+++ b/stories/dooboo-ui/SwitchToggleStories/SwitchToggleDefaultStory.tsx
@@ -34,7 +34,7 @@ const SwitchToggleDefault: FC = () => {
           <Typography.Heading3 style={{fontSize: 18, marginBottom: 8}}>
             Basic Style
           </Typography.Heading3>
-          <SwitchToggle switchOn={on} onPress={() => off(!on)} />
+          <SwitchToggle isOn={on} onPress={() => off(!on)} />
         </Container>
 
         <Container style={{paddingVertical: 30}}>
@@ -42,12 +42,14 @@ const SwitchToggleDefault: FC = () => {
             Custom Color
           </Typography.Heading3>
           <SwitchToggle
-            switchOn={on}
+            isOn={on}
             onPress={() => off(!on)}
-            circleColorOff={theme.disabled}
-            circleColorOn={theme.secondary}
-            backgroundColorOn={theme.placeholder}
-            backgroundColorOff={theme.textDisabled}
+            styles={{
+              circleColorOff: theme.disabled,
+              circleColorOn: theme.secondary,
+              backgroundColorOn: theme.placeholder,
+              backgroundColorOff: theme.textDisabled,
+            }}
           />
         </Container>
         <Container style={{paddingVertical: 30}}>
@@ -55,19 +57,21 @@ const SwitchToggleDefault: FC = () => {
             Custom Size
           </Typography.Heading3>
           <SwitchToggle
-            switchOn={on}
+            isOn={on}
             onPress={() => off(!on)}
-            containerStyle={{
-              marginTop: 16,
-              width: 106,
-              height: 48,
-              borderRadius: 25,
-              padding: 5,
-            }}
-            circleStyle={{
-              width: 40,
-              height: 40,
-              borderRadius: 20,
+            styles={{
+              containerStyle: {
+                marginTop: 16,
+                width: 106,
+                height: 48,
+                borderRadius: 25,
+                padding: 5,
+              },
+              circleStyle: {
+                width: 40,
+                height: 40,
+                borderRadius: 20,
+              },
             }}
           />
         </Container>


### PR DESCRIPTION
## Description
1. Apply styling convention of `dooboo-ui`.(style-styles)
2. Clean up unnecessary code and rename props.
3. Combine `leftText` and `leftIcon` to `onElement`. (same for right)
4. Enhance default value providing method.
5. Remove `type` and `RTL` prop. `RTL` feature can be implemented by user easily if needed. (Using rotate.) I think implement inside SwitchToggle makes codes far less readable.
6. Overall code refactoring.

## Related Issues
none.

## Tests
Rewite it. Since there are lots of customizable styles, I wrote simple on/off snapshot test checking everything(including styles) is applied correctly. Since this component doesn't have `Functionality`(It just move left to right. Everything is about style), I think simple snapshot testing is best suit for this.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
