### PR TITLE
Add CustomLoadingIndicator in demo

### DIFF
--- a/stories/Icon.tsx
+++ b/stories/Icon.tsx
@@ -9,6 +9,7 @@ import icEdit from './assets/icons/ic_edit.png';
 import icFacebook from './assets/icons/facebook.png';
 import icGoogle from './assets/icons/google.png';
 import icMagnifier from './assets/icons/magnifier.png';
+import icMask from './assets/icons/mask.png';
 
 export const IC_ARR_DOWN = icArrDown;
 export const IC_ARR_UP = icArrUp;
@@ -17,6 +18,7 @@ export const IC_EDIT = icEdit;
 export const IC_FACEBOOK = icFacebook;
 export const IC_GOOGLE = icGoogle;
 export const IC_MAGNIFIER = icMagnifier;
+export const IC_MASK = icMask;
 
 function ArrowDown(): React.ReactElement {
   return (

--- a/stories/dooboo-ui/LoadingIndicatorStories/CustomLoadingIndicator.tsx
+++ b/stories/dooboo-ui/LoadingIndicatorStories/CustomLoadingIndicator.tsx
@@ -1,0 +1,56 @@
+import {Animated, Easing, ImageStyle, StyleProp, View} from 'react-native';
+import React, {FC, useEffect, useState} from 'react';
+
+import {IC_MASK} from '../../Icon';
+
+type Props = {
+  style?: StyleProp<ImageStyle>;
+};
+
+const CustomLoadingIndicator: FC<Props> = ({style}) => {
+  const [spinAnim] = useState(new Animated.Value(0));
+
+  const spin = spinAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.timing(spinAnim, {
+        toValue: 1,
+        duration: 1600,
+        easing: Easing.linear,
+        useNativeDriver: false,
+      }),
+    ).start();
+  });
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignSelf: 'stretch',
+        backgroundColor: 'white',
+
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+      <Animated.Image
+        style={[
+          {
+            opacity: 0.95,
+            height: 56,
+            width: 56,
+            borderRadius: 28,
+            transform: [{rotate: spin}],
+          },
+          style,
+        ]}
+        source={IC_MASK}
+      />
+    </View>
+  );
+};
+
+export default CustomLoadingIndicator;

--- a/stories/dooboo-ui/LoadingIndicatorStories/index.tsx
+++ b/stories/dooboo-ui/LoadingIndicatorStories/index.tsx
@@ -2,6 +2,7 @@ import {LoadingIndicator, ThemeProvider} from '../../../main';
 import React, {ReactElement} from 'react';
 
 import {ContainerDeco} from '../../../storybook/decorators';
+import CustomLoadingIndicator from './CustomLoadingIndicator';
 import {storiesOf} from '@storybook/react-native';
 import styled from '@emotion/native';
 
@@ -71,5 +72,10 @@ storiesOf('LoadingIndicator', module)
   .add('imgVersion', () => (
     <ThemeProvider initialThemeType="light">
       <ImgVersion />
+    </ThemeProvider>
+  ))
+  .add('customIndicator', () => (
+    <ThemeProvider initialThemeType="light">
+      <CustomLoadingIndicator />
     </ThemeProvider>
   ));


### PR DESCRIPTION
## Description
Add customized loading indicator in demo for those who want to use their own image in loading indicator.

* This is a screenshot of the demo page.
![image](https://user-images.githubusercontent.com/64644738/131346510-62449224-bd7a-4c91-a0be-f1e308c544bb.png)

* This is how it loads.
![CustomLoading](https://user-images.githubusercontent.com/64644738/131347139-7e8832b0-24bd-4b73-8481-ddab4747b07b.gif)


## Related Issues

None.

## Tests

Basic render test.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.