### PR TITLE
Support Expo Snack for [Button] sample code

### DIFF
--- a/docs/src/components/Button/Button.stories.mdx
+++ b/docs/src/components/Button/Button.stories.mdx
@@ -9,6 +9,7 @@ import {
   Sizes,
   Solid,
   Disabled,
+  Link
 } from './index';
 
 <Meta title="Components/Button" />
@@ -57,6 +58,8 @@ import {Button} from 'dooboo-ui';
 <Basic themeType="light" />
 <Basic themeType="dark" />
 
+<Link link="https://snack.expo.dev/@swda/basic-style" />
+
 ### Solid Color type
 
 `primary` `secondary` `success` `danger` `warning` `info` `light`
@@ -77,6 +80,8 @@ The default value of type is `primary`.
 <Solid themeType="light" />
 <Solid themeType="dark" />
 
+<Link link="https://snack.expo.dev/@swda/solid-color-type"/>
+
 ### Outlined Color type
 
 Generate bordering button by adding `outlined` prop.
@@ -94,6 +99,8 @@ Generate bordering button by adding `outlined` prop.
 <Outlined themeType="light" />
 <Outlined themeType="dark" />
 
+<Link link="https://snack.expo.dev/@swda/outlined-color-type"/>
+
 ### Disabled button
 
 The `disabled` prop can generate disabled button which is not pressed.
@@ -106,6 +113,8 @@ And it can't apply `type`.
 
 <Disabled themeType="light" />
 <Disabled themeType="dark" />
+
+<Link link="https://snack.expo.dev/@swda/disabled-button"/>
 
 ### Loading
 
@@ -122,6 +131,8 @@ And change loading spinner color by using `indicatorColor` prop.
 <Loading themeType="light" />
 <Loading themeType="dark" />
 
+<Link link="https://snack.expo.dev/@swda/loading"/>
+
 ### Aspect of sizes
 
 `large` `medium` `small`
@@ -136,6 +147,8 @@ The `size` prop can generate many size buttons.
 
 <Sizes themeType="light" />
 <Sizes themeType="dark" />
+
+<Link link="https://snack.expo.dev/@swda/aspect-of-sizes"/>
 
 ### `onPress` event
 
@@ -170,6 +183,8 @@ return (
 
 <OnPress themeType="light" />
 <OnPress themeType="dark" />
+
+<Link link="https://snack.expo.dev/@swda/onpress-event"/>
 
 ### AdditionalElement
 
@@ -251,3 +266,5 @@ return (
 
 <AdditionalElement themeType="light" />
 <AdditionalElement themeType="dark" />
+
+<Link link="https://snack.expo.dev/@swda/additionalelement"/>

--- a/docs/src/components/Button/Link.tsx
+++ b/docs/src/components/Button/Link.tsx
@@ -1,0 +1,33 @@
+import {Button, ThemeProvider} from 'dooboo-ui';
+import {Linking, StyleSheet, View} from 'react-native';
+
+import type {FC} from 'react';
+import React from 'react';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+});
+
+type LinkProps = {
+  link: string;
+};
+
+export const Link: FC<LinkProps> = ({link}) => {
+  return (
+    <ThemeProvider>
+      <View style={styles.container}>
+        <Button
+          type="info"
+          text="Try this example on Snack"
+          size="medium"
+          style={{paddingTop: 15}}
+          onPress={() => Linking.openURL(link)}
+        />
+      </View>
+    </ThemeProvider>
+  );
+};

--- a/docs/src/components/Button/index.tsx
+++ b/docs/src/components/Button/index.tsx
@@ -6,3 +6,4 @@ export * from './OnPress';
 export * from './Solid';
 export * from './Disabled';
 export * from './Loading';
+export * from './Link';


### PR DESCRIPTION
## Description

Support Expo Snack for [Button] sample code in storybook.
Add "Link" Button below the sample code. When you click the button, it goes to Expo Snack.

![스크린샷 2021-09-07 오전 2 54 53](https://user-images.githubusercontent.com/42320180/132250613-a9e766ae-f1f4-49cf-acbc-e065ab8297c8.png)

When you click the button.

![스크린샷 2021-09-07 오전 2 55 39](https://user-images.githubusercontent.com/42320180/132250655-beac25d7-2edc-41a3-8fdc-de50bf1348b1.png)


## Related Issues

related #57 

## Tests

X

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
