### PR TITLE
Enhance useTheme to provide default theme without ThemeProvider

### DIFF
--- a/main/SwitchToggle.tsx
+++ b/main/SwitchToggle.tsx
@@ -1,10 +1,8 @@
 import {Animated, StyleProp, TouchableOpacity, ViewStyle} from 'react-native';
-import {DoobooTheme, light} from './theme';
 import React, {ReactElement, useEffect, useState} from 'react';
 
-import {isEmptyObject} from './utils';
 import styled from '@emotion/native';
-import {withTheme} from '@emotion/react';
+import {useTheme} from './theme/ThemeProvider';
 
 interface Styles {
   containerStyle?: ViewStyle;
@@ -21,7 +19,6 @@ interface Styles {
 interface Props {
   testID?: string;
   isOn: boolean;
-  theme?: DoobooTheme;
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
   duration?: number;
@@ -50,7 +47,7 @@ const defaultCircleStyle: ViewStyle = {
   borderRadius: 16,
 };
 
-function Component(props: Props): React.ReactElement {
+export function SwitchToggle(props: Props): ReactElement {
   const {
     testID,
     isOn,
@@ -62,10 +59,9 @@ function Component(props: Props): React.ReactElement {
     onPress,
   } = props;
 
-  const theme =
-    !props.theme || isEmptyObject(props.theme) ? light : props.theme;
-
-  const {primary, disabled, textContrast, placeholder} = theme;
+  const {
+    theme: {primary, disabled, textContrast, placeholder},
+  } = useTheme();
 
   const {
     backgroundColorOn = primary,
@@ -195,5 +191,3 @@ function Component(props: Props): React.ReactElement {
     </TouchableOpacity>
   );
 }
-
-export const SwitchToggle = withTheme(Component);

--- a/main/theme/ThemeProvider.tsx
+++ b/main/theme/ThemeProvider.tsx
@@ -7,6 +7,7 @@ import {
 import React, {useEffect, useState} from 'react';
 
 import {ColorSchemeName} from 'react-native';
+import {DoobooTheme} from '.';
 import createCtx from './createCtx';
 import useColorScheme from './useColorScheme';
 import {useMediaQuery} from 'react-responsive';
@@ -89,4 +90,13 @@ function ThemeProvider({
   );
 }
 
-export {useCtx as useTheme, ThemeProvider, withTheme};
+const useTheme = (): Context | {theme: DoobooTheme} => {
+  const currentTheme = useCtx();
+  const defaultTheme = light;
+
+  if (!currentTheme) return {theme: defaultTheme}!;
+
+  return currentTheme;
+};
+
+export {useTheme, ThemeProvider, withTheme};

--- a/main/theme/ThemeProvider.tsx
+++ b/main/theme/ThemeProvider.tsx
@@ -45,7 +45,7 @@ function ThemeProvider({
 
   const colorScheme = useColorScheme();
 
-  const [themeType, setThemeType] = useState(initialThemeType || colorScheme);
+  const [themeType, setThemeType] = useState(initialThemeType ?? colorScheme);
 
   useEffect(() => {
     if (!initialThemeType) setThemeType(colorScheme);
@@ -61,10 +61,10 @@ function ThemeProvider({
     setThemeType(themeTypeProp);
   };
 
-  const defaultTheme =
-    themeType === 'dark'
-      ? {...dark, ...customTheme?.dark}
-      : {...light, ...customTheme?.light};
+  const theme = {
+    light: {...light, ...customTheme?.light},
+    dark: {...dark, ...customTheme?.dark},
+  }[themeType ?? 'light'];
 
   const media = {
     isPortrait,
@@ -73,18 +73,18 @@ function ThemeProvider({
     isDesktop,
   };
 
-  const theme: DefaultTheme = {...defaultTheme, ...media};
-
   return (
     <Provider
       value={{
         media,
         themeType,
         changeThemeType,
-        theme: defaultTheme,
+        theme,
         colors,
       }}>
-      <OriginalThemeProvider theme={theme}>{children}</OriginalThemeProvider>
+      <OriginalThemeProvider theme={{...theme, ...media}}>
+        {children}
+      </OriginalThemeProvider>
     </Provider>
   );
 }

--- a/main/theme/ThemeProvider.tsx
+++ b/main/theme/ThemeProvider.tsx
@@ -90,11 +90,11 @@ function ThemeProvider({
   );
 }
 
-const useTheme = (): Context | {theme: DoobooTheme} => {
+const useTheme = (): Context => {
   const currentTheme = useCtx();
   const defaultTheme = light;
 
-  if (!currentTheme) return {theme: defaultTheme}!;
+  if (!currentTheme) return {theme: defaultTheme} as Context;
 
   return currentTheme;
 };

--- a/main/theme/ThemeProvider.tsx
+++ b/main/theme/ThemeProvider.tsx
@@ -7,7 +7,6 @@ import {
 import React, {useEffect, useState} from 'react';
 
 import {ColorSchemeName} from 'react-native';
-import {DoobooTheme} from '.';
 import createCtx from './createCtx';
 import useColorScheme from './useColorScheme';
 import {useMediaQuery} from 'react-responsive';
@@ -25,7 +24,7 @@ interface Context {
   colors: Colors;
 }
 
-const [useCtx, Provider] = createCtx<Context>();
+const [useCtx, Provider] = createCtx<Context>({theme: light} as Context);
 
 interface Props {
   children?: React.ReactElement;
@@ -90,13 +89,4 @@ function ThemeProvider({
   );
 }
 
-const useTheme = (): Context => {
-  const currentTheme = useCtx();
-  const defaultTheme = light;
-
-  if (!currentTheme) return {theme: defaultTheme} as Context;
-
-  return currentTheme;
-};
-
-export {useTheme, ThemeProvider, withTheme};
+export {useCtx as useTheme, ThemeProvider, withTheme};

--- a/main/theme/createCtx.tsx
+++ b/main/theme/createCtx.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
 type CreateCtx<A> = readonly [
-  () => A | undefined,
-  React.ProviderExoticComponent<React.ProviderProps<A | undefined>>,
+  () => A,
+  React.ProviderExoticComponent<React.ProviderProps<A>>,
 ];
 
 // create context with no upfront defaultValue
 // without having to do undefined check all the time
-function createCtx<A>(): CreateCtx<A> {
-  const ctx = React.createContext<A | undefined>(undefined);
+function createCtx<A>(defaultContext: A): CreateCtx<A> {
+  const ctx = React.createContext<A>(defaultContext);
 
-  const useCtx = (): A | undefined => React.useContext(ctx);
+  const useCtx = (): A => React.useContext(ctx);
 
   // make TypeScript infer a tuple, not an array of union types
   return [useCtx, ctx.Provider] as const;

--- a/main/theme/createCtx.tsx
+++ b/main/theme/createCtx.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 type CreateCtx<A> = readonly [
-  () => A,
+  () => A | undefined,
   React.ProviderExoticComponent<React.ProviderProps<A | undefined>>,
 ];
 
@@ -10,13 +10,7 @@ type CreateCtx<A> = readonly [
 function createCtx<A>(): CreateCtx<A> {
   const ctx = React.createContext<A | undefined>(undefined);
 
-  function useCtx(): A {
-    const c = React.useContext(ctx);
-
-    if (!c) throw new Error('useCtx must be inside a Provider with a value');
-
-    return c;
-  }
+  const useCtx = (): A | undefined => React.useContext(ctx);
 
   // make TypeScript infer a tuple, not an array of union types
   return [useCtx, ctx.Provider] as const;


### PR DESCRIPTION
## Description
In Short: Providing default theme using `withTheme`, `default value`, etc... often fails. This PR solve this problem by enhancing `useTheme` in `dooboo-ui`. Now, `useTheme` will at least return default theme(light) even if there aren't `ThemeProvider` exists.

---


Providing theme is complicated task. And providing default theme is harder.

`dooboo-ui` aims to provide default theme even if user forget to wrap componets with `ThemeProvider`.

Currently, theme providing is done by this.

```jsx
const ButtonComponent: FC<ButtonProps & {theme: DoobooTheme}> = ({})

export const Button = withTheme(ButtonComponent);
```

and providing default theme(when `ThemeProvider` is not provided) is done by this.

```jsx
// Sol 1
ButtonComponent.defaultProps = {theme: defaultTheme};

// Sol 2
const {theme = defaultTheme} = props
```

However, default theme is not applied as I mentioned in #104.

It is because `withTheme` from `emotion` provides `{ }` when there aren't any theme to provide. So `props.theme` is never `undefined`, resulting our defaultTheme never applied. **See [this line](https://github.com/emotion-js/emotion/blob/bb99600fcfecbd1d381cdc558d885732142c3112/packages/create-emotion-styled/src/index.js#L102) of emotion implementation.**

So, I made a [workaround](https://github.com/yujong-lee/dooboo-ui/blob/acfd5aed41e9a927e0e35fd1a0f11c81e37b0a76/main/SwitchToggle.tsx#L66-L69) in #86 using `isEmptyObject`.

---

But it is just a workaround. It should be much easier and effortless to do it.
So I re-write `useTheme` and provide `light` to be default theme.

Now, there's no need to have `theme prop`, `withTheme HOC`, and `default value`. All you need to do to get current theme is calling `useTheme`. This will reduce confusion a lot.

In this PR, I refactor only `SwitchToggle` using new `useTheme`.

## Test Plan
none.

## Related Issues
#104 

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
