### PR TITLE
Replace source prop with uri prop in [NetworkImage]

### DIFF
--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -22,7 +22,7 @@ type Styles = {
 interface Props {
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
-  uri: string | undefined;
+  url: string | undefined;
   defaultSource?: ImageSourcePropType;
   loadingElement?: ReactElement;
   imageProps?: Partial<ImageProps>;
@@ -34,6 +34,21 @@ type ImageSize = {
   height: number;
 };
 
+const fetchImageSize = (imageUrl: string): Promise<ImageSize> =>
+  new Promise<ImageSize>((resolve, reject) =>
+    Image.getSize(
+      imageUrl,
+      (width: number, height: number) =>
+        resolve({
+          width,
+          height,
+        }),
+      (error) => {
+        reject(error);
+      },
+    ),
+  );
+
 function NetworkImage(props: Props): ReactElement {
   const {themeType} = useTheme();
 
@@ -43,7 +58,7 @@ function NetworkImage(props: Props): ReactElement {
     style,
     imageProps,
     loadingElement = <LoadingIndicator style={activityIndicator} />,
-    uri,
+    url,
     defaultSource = themeType === 'light'
       ? ArtifactsLogoLight
       : ArtifactsLogoDark,
@@ -58,27 +73,12 @@ function NetworkImage(props: Props): ReactElement {
   });
 
   useLayoutEffect(() => {
-    const fetchImageSize = (imageUri: string): Promise<ImageSize> =>
-      new Promise<ImageSize>((resolve, reject) =>
-        Image.getSize(
-          imageUri,
-          (width: number, height: number) =>
-            resolve({
-              width,
-              height,
-            }),
-          (error) => {
-            reject(error);
-          },
-        ),
-      );
-
-    if (!uri) setIsValidSource(false);
+    if (!url) setIsValidSource(false);
     else
-      fetchImageSize(uri)
+      fetchImageSize(url)
         .then((value) => setSize(value))
         .catch(() => setIsValidSource(false));
-  }, [uri]);
+  }, [url]);
 
   return (
     <View
@@ -107,7 +107,7 @@ function NetworkImage(props: Props): ReactElement {
         resizeMethod="resize"
         resizeMode="cover"
         onLoad={() => setNeedLoading(false)}
-        source={isValidSource ? {uri} : defaultSource}
+        source={isValidSource ? {url} : defaultSource}
         {...imageProps}
       />
 

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -25,7 +25,7 @@ function NetworkImageStory(): React.ReactElement {
           height: 300,
         }}
         styles={{image: {width: '50%'}}}
-        uri="https://reactnative.dev/img/tiny_logo.png"
+        url="https://reactnative.dev/img/tiny_logo.png"
       />
       <NetworkImage
         style={{
@@ -33,7 +33,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        uri="https://wronglink.co"
+        url="https://wronglink.co"
       />
       <NetworkImage
         style={{
@@ -41,7 +41,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        uri="https://media.vlpt.us/images/luck2901/post/5745952f-eb96-4784-b01c-2eb90158ace7/React_Native_Tutorial.jpg"
+        url="https://media.vlpt.us/images/luck2901/post/5745952f-eb96-4784-b01c-2eb90158ace7/React_Native_Tutorial.jpg"
       />
       <NetworkImage
         style={{
@@ -49,7 +49,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        uri="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
+        url="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
       />
     </ScrollContainer>
   );

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -25,7 +25,7 @@ function NetworkImageStory(): React.ReactElement {
           height: 300,
         }}
         styles={{image: {width: '50%'}}}
-        source={{uri: 'https://reactnative.dev/img/tiny_logo.png'}}
+        uri="https://reactnative.dev/img/tiny_logo.png"
       />
       <NetworkImage
         style={{
@@ -33,9 +33,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        source={{
-          uri: 'https://wronglink.co',
-        }}
+        uri="https://wronglink.co"
       />
       <NetworkImage
         style={{
@@ -43,9 +41,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        source={{
-          uri: 'https://media.vlpt.us/images/luck2901/post/5745952f-eb96-4784-b01c-2eb90158ace7/React_Native_Tutorial.jpg',
-        }}
+        uri="https://media.vlpt.us/images/luck2901/post/5745952f-eb96-4784-b01c-2eb90158ace7/React_Native_Tutorial.jpg"
       />
       <NetworkImage
         style={{
@@ -53,9 +49,7 @@ function NetworkImageStory(): React.ReactElement {
           width: 180,
           height: 180,
         }}
-        source={{
-          uri: 'https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg',
-        }}
+        uri="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
       />
     </ScrollContainer>
   );


### PR DESCRIPTION
## Description
Considering role of NetworkImage, it is unnecessary to provide `ImageSourcePropType`. Just uri: `string` is appropriate.

## Test Plan
It will be automated with `Storyshot` and `Chromatic`.
See [roadmap](https://github.com/dooboolab/dooboo-ui/discussions/114).

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
