### PR TITLE
Update PR template with yarn test:all

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,5 @@ will likely get reverted accidentally sooner or later. PRs must include tests fo
 Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
 
 - [ ] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
-- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
-- [ ] Run `yarn lint`
+- [ ] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
 - [ ] I am willing to follow-up on review comments in a timely manner.


### PR DESCRIPTION
## Description
CI failures occur really often when many people, including myself, send PR. This makes communication inefficient and builds unnecessary commits.

I think this is because there are too many steps needed to make sure everything is fine, and it is clear to guide only one `yarn test:all` command rather than to guide test, lint, build, etc.

## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
