### PR TITLE
Remove nested component declaration in [AlertDialog]

### DIFF
--- a/packages/AlertDialog/index.tsx
+++ b/packages/AlertDialog/index.tsx
@@ -118,9 +118,6 @@ const AlertDialog = React.forwardRef<Modal, Props>(
         {title && <Title>{title}</Title>}
         {content && <Content>{content}</Content>}
 
-        {type === 'prompt' && (
-          <ModalInput value={input} onChangeText={setInput} />
-        )}
         {type === 'alert' && renderPrimaryButton(() => onPress(true))}
         {type === 'confirm' && (
           <>
@@ -130,6 +127,7 @@ const AlertDialog = React.forwardRef<Modal, Props>(
         )}
         {type === 'prompt' && (
           <>
+            <ModalInput value={input} onChangeText={setInput} />
             {renderAdditionalButton(() => {
               onPress(null);
               setInput('');

--- a/packages/AlertDialog/index.tsx
+++ b/packages/AlertDialog/index.tsx
@@ -96,44 +96,6 @@ const AlertDialog = React.forwardRef<Modal, Props>(
   ) => {
     const [input, setInput] = useState('');
 
-    const AlertButton: React.FC = () => {
-      const primaryOnPress: VoidFunction = () => onPress(true);
-
-      return <>{renderPrimaryButton(primaryOnPress)}</>;
-    };
-
-    const ConfirmButton: React.FC = () => {
-      const primaryOnPress: VoidFunction = () => onPress(true);
-
-      const additionalOnPress: VoidFunction = () => onPress(false);
-
-      return (
-        <>
-          {renderAdditionalButton(additionalOnPress)}
-          {renderPrimaryButton(primaryOnPress)}
-        </>
-      );
-    };
-
-    const PromptButton: React.FC = () => {
-      const primaryOnPress: VoidFunction = () => {
-        onPress(input);
-        setInput('');
-      };
-
-      const additionalOnPress: VoidFunction = () => {
-        onPress(null);
-        setInput('');
-      };
-
-      return (
-        <>
-          {renderAdditionalButton(additionalOnPress)}
-          {renderPrimaryButton(primaryOnPress)}
-        </>
-      );
-    };
-
     return (
       <Modal
         isOpen={isOpen}
@@ -155,12 +117,29 @@ const AlertDialog = React.forwardRef<Modal, Props>(
         backdropPressToClose={backdropPressToClose}>
         {title && <Title>{title}</Title>}
         {content && <Content>{content}</Content>}
+
         {type === 'prompt' && (
           <ModalInput value={input} onChangeText={setInput} />
         )}
-        {type === 'alert' && <AlertButton />}
-        {type === 'confirm' && <ConfirmButton />}
-        {type === 'prompt' && <PromptButton />}
+        {type === 'alert' && renderPrimaryButton(() => onPress(true))}
+        {type === 'confirm' && (
+          <>
+            {renderAdditionalButton(() => onPress(false))}
+            {renderPrimaryButton(() => onPress(true))}
+          </>
+        )}
+        {type === 'prompt' && (
+          <>
+            {renderAdditionalButton(() => {
+              onPress(null);
+              setInput('');
+            })}
+            {renderPrimaryButton(() => {
+              onPress(input);
+              setInput('');
+            })}
+          </>
+        )}
       </Modal>
     );
   },


### PR DESCRIPTION
## Description

1. Component declarations shouldn't be nested. React will be unable to reconcile the rendering of these components, as they are treated as new components every time. Also, they are messy and hard to test.
2. Inline components and handlers.

```js
{type === 'prompt' && <PromptButton />}
```

Since `Prompt` is repeating, there are no use to declare `PromptButton`.

```js
{renderAdditionalButton(additionalOnPress)}
```
Since `Additional` is repeating, there are no use to declare `additionalOnPress`. 


## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
