### PR TITLE
Remove unnecessary properties in Theme declaration

### DIFF
--- a/docs/src/styled.d.ts
+++ b/docs/src/styled.d.ts
@@ -2,10 +2,5 @@ import '@emotion/react';
 import type {DoobooTheme} from 'dooboo-ui';
 
 declare module '@emotion/react' {
-  export interface Theme extends DoobooTheme {
-    isPortrait?: boolean;
-    isMobile?: boolean;
-    isTablet?: boolean;
-    isDesktop?: boolean;
-  }
+  export interface Theme extends DoobooTheme {}
 }

--- a/main/theme/styled.d.ts
+++ b/main/theme/styled.d.ts
@@ -2,10 +2,5 @@ import '@emotion/react';
 import type {DoobooTheme} from './index';
 
 declare module '@emotion/react' {
-  export interface Theme extends DoobooTheme {
-    isPortrait?: boolean;
-    isMobile?: boolean;
-    isTablet?: boolean;
-    isDesktop?: boolean;
-  }
+  export interface Theme extends DoobooTheme {}
 }


### PR DESCRIPTION
## Description

Remove unnecessary properties in Theme declaration.

Since `DoobooTheme` already has those properties, it's better to remove them.

```ts
export type DoobooTheme = typeof light & {
  isPortrait?: boolean;
  isDesktop?: boolean;
  isTablet?: boolean;
  isMobile?: boolean;
};
```

## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
