### PR TITLE
hotfix: Fix layout styles in [NetworkImage]

### DIFF
--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -7,14 +7,17 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import React, {ReactElement, useEffect, useState, isValidElement} from 'react';
-import {useTheme} from './theme';
+import React, {ReactElement, isValidElement, useEffect, useState} from 'react';
 
 import ArtifactsLogoDark from './__assets__/artifacts_logo_d.png';
 import ArtifactsLogoLight from './__assets__/artifacts_logo_l.png';
+import {useTheme} from './theme';
 
 type Styles = {
-  image?: Omit<ImageStyle, 'width' | 'height'>;
+  image?: Omit<
+    ImageStyle,
+    'width' | 'height' | 'minHeight' | 'minWidth' | 'maxHeight' | 'maxWidth'
+  >;
   loading?: ImageStyle;
 };
 
@@ -73,9 +76,7 @@ function NetworkImage(props: Props): ReactElement {
     <View
       style={[
         {
-          flex: 1,
-          alignSelf: 'stretch',
-
+          flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
         },
@@ -97,10 +98,7 @@ function NetworkImage(props: Props): ReactElement {
 
       {!needLoading && !isValidSource && (
         <Image
-          style={[
-            {flex: 1, alignSelf: 'stretch', aspectRatio: 110 / 74},
-            image,
-          ]}
+          style={[{width: '50%', height: '50%', aspectRatio: 110 / 74}, image]}
           source={fallbackSource}
           resizeMethod="resize"
           resizeMode="cover"

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -31,7 +31,7 @@ function NetworkImageStory(): React.ReactElement {
           margin: 20,
           alignSelf: 'center',
         }}
-        styles={{image: {borderRadius: 100, backgroundColor: 'red'}}}
+        styles={{image: {borderRadius: 100}}}
         url="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
       />
 
@@ -39,7 +39,7 @@ function NetworkImageStory(): React.ReactElement {
         <NetworkImage
           style={{width: 300, height: 300, margin: 20, alignSelf: 'center'}}
           styles={{
-            loading: {backgroundColor: 'red', width: 300, height: 300},
+            loading: {width: 300, height: 300},
             image: {borderRadius: 45},
           }}
           loadingSource={
@@ -59,6 +59,7 @@ function NetworkImageStory(): React.ReactElement {
       <View>
         <NetworkImage
           style={{
+            backgroundColor: 'red',
             width: 300,
             height: 300,
           }}

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -1,13 +1,12 @@
 import {NetworkImage, ThemeProvider, Typography, useTheme} from '../../../main';
 import React, {ReactElement} from 'react';
-import {View} from 'react-native';
-
-import {ContainerDeco} from '../../../storybook/decorators';
-import {storiesOf} from '@storybook/react-native';
-import styled from '@emotion/native';
 
 import ArtifactsLogoDark from '../../../main/__assets__/artifacts_logo_d.png';
 import ArtifactsLogoLight from '../../../main/__assets__/artifacts_logo_l.png';
+import {ContainerDeco} from '../../../storybook/decorators';
+import {View} from 'react-native';
+import {storiesOf} from '@storybook/react-native';
+import styled from '@emotion/native';
 
 const ScrollContainer = styled.ScrollView`
   width: 100%;
@@ -26,13 +25,19 @@ function NetworkImageStory(): React.ReactElement {
       }}
     >
       <NetworkImage
-        style={{width: 300, height: 300, margin: 20, alignSelf: 'center'}}
+        style={{
+          width: 300,
+          height: 300,
+          margin: 20,
+          alignSelf: 'center',
+        }}
         styles={{image: {borderRadius: 100, backgroundColor: 'red'}}}
         url="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
       />
 
       <View style={{width: 300, height: 300, margin: 20}}>
         <NetworkImage
+          style={{width: 300, height: 300, margin: 20, alignSelf: 'center'}}
           styles={{
             loading: {backgroundColor: 'red', width: 300, height: 300},
             image: {borderRadius: 45},
@@ -51,8 +56,14 @@ function NetworkImageStory(): React.ReactElement {
         url="https://reactnative.dev/img/tiny_logo.png"
       />
 
-      <View style={{width: 300, height: 300, margin: 20}}>
-        <NetworkImage style={{alignSelf: 'center'}} url="wrong link" />
+      <View>
+        <NetworkImage
+          style={{
+            width: 300,
+            height: 300,
+          }}
+          url="wrong link"
+        />
       </View>
     </ScrollContainer>
   );


### PR DESCRIPTION
## Description

When url is `undefined`, Image with `fallbackSource` looks weired in android and ios. This is because `flex:1, alignself:'stretch` was not applied properly to `Image` with `png`.  So I fixed the style.


[changes]
- The user should pass the `width` and `height` to style props.
- `fallbackSource` now has `'width: '50%', height: 50%'`

![image](https://user-images.githubusercontent.com/58724686/134465568-cae63b0a-c6c5-4030-b7fb-f8b64dcfa185.png)

## Test Plan

snapshot update

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
