### PR TITLE
Fix fallbackImage and loadingImage style

### DIFF
--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -12,6 +12,7 @@ import React, {ReactElement, isValidElement, useEffect, useState} from 'react';
 import ArtifactsLogoDark from './__assets__/artifacts_logo_d.png';
 import ArtifactsLogoLight from './__assets__/artifacts_logo_l.png';
 import {useTheme} from './theme';
+import {css} from '@emotion/native';
 
 type Styles = {
   image?: Omit<
@@ -30,6 +31,12 @@ interface Props {
   imageProps?: Partial<ImageProps>;
 }
 
+const defaultImage = css({
+  aspectRatio: 110 / 74,
+  maxWidth: '50%',
+  maxHeight: '50%',
+});
+
 function NetworkImage(props: Props): ReactElement {
   const {theme, themeType} = useTheme();
 
@@ -43,13 +50,7 @@ function NetworkImage(props: Props): ReactElement {
     props?.loadingSource
   ) : (
     <Image
-      style={[
-        {
-          aspectRatio: 110 / 74,
-          position: 'absolute',
-        },
-        loading,
-      ]}
+      style={[{position: 'absolute'}, defaultImage, loading]}
       source={props?.loadingSource ?? logo}
       resizeMethod="resize"
       resizeMode="cover"
@@ -98,7 +99,7 @@ function NetworkImage(props: Props): ReactElement {
 
       {!needLoading && !isValidSource && (
         <Image
-          style={[{width: '50%', height: '50%', aspectRatio: 110 / 74}, image]}
+          style={[defaultImage, image]}
           source={fallbackSource}
           resizeMethod="resize"
           resizeMode="cover"

--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -33,8 +33,8 @@ interface Props {
 
 const defaultImage = css({
   aspectRatio: 110 / 74,
-  maxWidth: '50%',
-  maxHeight: '50%',
+  width: '50%',
+  height: 'auto',
 });
 
 function NetworkImage(props: Props): ReactElement {

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -1,8 +1,6 @@
-import {NetworkImage, ThemeProvider, Typography, useTheme} from '../../../main';
+import {NetworkImage, ThemeProvider, Typography} from '../../../main';
 import React, {ReactElement} from 'react';
 
-import ArtifactsLogoDark from '../../../main/__assets__/artifacts_logo_d.png';
-import ArtifactsLogoLight from '../../../main/__assets__/artifacts_logo_l.png';
 import {ContainerDeco} from '../../../storybook/decorators';
 import {View} from 'react-native';
 import {storiesOf} from '@storybook/react-native';
@@ -14,8 +12,6 @@ const ScrollContainer = styled.ScrollView`
 `;
 
 function NetworkImageStory(): React.ReactElement {
-  const {themeType} = useTheme();
-
   return (
     <ScrollContainer
       contentContainerStyle={{
@@ -26,12 +22,12 @@ function NetworkImageStory(): React.ReactElement {
     >
       <NetworkImage
         style={{
-          width: 300,
-          height: 300,
+          width: 110,
+          height: 110,
           margin: 20,
           alignSelf: 'center',
         }}
-        styles={{image: {borderRadius: 100}}}
+        styles={{image: {borderRadius: 50}}}
         url="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
       />
 
@@ -39,12 +35,9 @@ function NetworkImageStory(): React.ReactElement {
         <NetworkImage
           style={{width: 300, height: 300, margin: 20, alignSelf: 'center'}}
           styles={{
-            loading: {width: 300, height: 300},
+            loading: {maxWidth: 300, maxHeight: 300},
             image: {borderRadius: 45},
           }}
-          loadingSource={
-            themeType === 'light' ? ArtifactsLogoDark : ArtifactsLogoLight
-          }
           url="https://reactnative.dev/img/tiny_logo.png"
         />
       </View>

--- a/stories/dooboo-ui/NetworkImageStories/index.tsx
+++ b/stories/dooboo-ui/NetworkImageStories/index.tsx
@@ -33,11 +33,8 @@ function NetworkImageStory(): React.ReactElement {
 
       <View style={{width: 300, height: 300, margin: 20}}>
         <NetworkImage
-          style={{width: 300, height: 300, margin: 20, alignSelf: 'center'}}
-          styles={{
-            loading: {maxWidth: 300, maxHeight: 300},
-            image: {borderRadius: 45},
-          }}
+          style={{flex: 1, margin: 20}}
+          styles={{image: {borderRadius: 45}}}
           url="https://reactnative.dev/img/tiny_logo.png"
         />
       </View>


### PR DESCRIPTION
## Description

This PR solve problem that size of `loading` image is always same.
Now, it is `50%`. But it is `width 50%` and `height auto`. This is for preserving `aspectRatio` of image.
(It affects to fallback image too.)

https://user-images.githubusercontent.com/61503739/134767352-8527c788-1a69-4ae2-8232-0e5c06e1451f.mov


## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
