### PR TITLE
Enhance CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          check-latest: false
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
 
       - name: Install modules
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Lerna init
         run: yarn pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install modules
-        run: yarn install --frozen-lockfile
+        run: yarn
 
       - name: Lerna init
         run: yarn pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test:all --coverage
+        run: yarn test --coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install modules
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Lerna init
         run: yarn pre


### PR DESCRIPTION
## Description
1. Use `yarn install --frozen-lockfile` instead of `yarn`. It looks lot slower(up to 20s), but recommended for `CI`. It is similar to `npm ci`.

Screenshot from [yarn](https://classic.yarnpkg.com/en/docs/cli/install/)

<img width="715" alt="스크린샷 2021-09-28 오후 5 01 57" src="https://user-images.githubusercontent.com/61503739/135048281-099a4fbd-f9f0-4a94-ae64-51a008d9a3d8.png">


2. Cache `node` and `cache file of yarn` to make process faster.
3. Replace `yarn test:all` with `yarn test` because process is duplicated with previous one such as `lerna run build`.
## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
