### PR TITLE
Enhance styling in [NetworkImage] to be easy and flexible

### DIFF
--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -101,7 +101,7 @@ function NetworkImage(props: Props): ReactElement {
 
       {!needLoading && !isValidSource && (
         <Image
-          style={[defaultImage, image, fallback]}
+          style={[defaultImage, fallback]}
           source={fallbackSource}
           resizeMethod="resize"
           resizeMode="cover"

--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -11,8 +11,8 @@ import React, {ReactElement, isValidElement, useEffect, useState} from 'react';
 
 import ArtifactsLogoDark from './__assets__/artifacts_logo_d.png';
 import ArtifactsLogoLight from './__assets__/artifacts_logo_l.png';
-import {useTheme} from './theme';
 import {css} from '@emotion/native';
+import {useTheme} from './theme';
 
 type Styles = {
   image?: Omit<
@@ -20,6 +20,7 @@ type Styles = {
     'width' | 'height' | 'minHeight' | 'minWidth' | 'maxHeight' | 'maxWidth'
   >;
   loading?: ImageStyle;
+  fallback?: ImageStyle;
 };
 
 interface Props {
@@ -35,6 +36,7 @@ const defaultImage = css({
   aspectRatio: 110 / 74,
   width: '50%',
   height: 'auto',
+  maxHeight: '50%',
 });
 
 function NetworkImage(props: Props): ReactElement {
@@ -44,13 +46,13 @@ function NetworkImage(props: Props): ReactElement {
 
   const {style, url, imageProps, fallbackSource = logo} = props;
 
-  const {image, loading} = props.styles ?? {};
+  const {image, loading, fallback} = props.styles ?? {};
 
   const loadingSource: ReactElement = isValidElement(props?.loadingSource) ? (
     props?.loadingSource
   ) : (
     <Image
-      style={[{position: 'absolute'}, defaultImage, loading]}
+      style={[defaultImage, loading]}
       source={props?.loadingSource ?? logo}
       resizeMethod="resize"
       resizeMode="cover"
@@ -99,7 +101,7 @@ function NetworkImage(props: Props): ReactElement {
 
       {!needLoading && !isValidSource && (
         <Image
-          style={[defaultImage, image]}
+          style={[defaultImage, image, fallback]}
           source={fallbackSource}
           resizeMethod="resize"
           resizeMode="cover"

--- a/main/NetworkImage.tsx
+++ b/main/NetworkImage.tsx
@@ -79,7 +79,6 @@ function NetworkImage(props: Props): ReactElement {
     <View
       style={[
         {
-          flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
         },


### PR DESCRIPTION
## Description

1. Remove `absolute` in `defaultImage` style.
It was needed in past, but it is now useless and result in unexpected behavior.

2. Add `maxHeight` to `defaultImage` style.
Since `height` is `auto` calculated base on `ratio` and `width: 50%`, `height` can be bigger than boundary. This is not expected behavior, so this should be restricted with `maxHeight`.

3. Add `fallback` in `styles`. Because it is more flexible. Also, it is more predictable for user. Because `Networkimage` has 3 state of image. `image(final image to show)`, `loading` and `fallback`, so it is expected to have 3 properties in `styles` for each of them.

Note that `fallback Image` has `style=[defaultImage, image, fallback]`. This is because it is natural that `image` and `fallbackImage` have same style(such as size), but there can be some edge case. (If `borderRadius` is applied to `image` and `fallbackImage` is transparent logo. This case, `fallback = {{borderRadius : undefined}}` might be needed.)

## Test Plan
none.

## Related Issues
none.

## Tests
none.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
