### PR TITLE
[fix] Change Gap between the FAB buttons.

### DIFF
--- a/main/FAB/index.tsx
+++ b/main/FAB/index.tsx
@@ -22,6 +22,7 @@ interface Styles {
   FABItem?: StyleProp<ViewStyle>;
   buttonSize: ButtonSize;
   iconSize?: number;
+  gap?: number;
 }
 
 export interface FABItem {
@@ -53,12 +54,17 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
 }: FABProps<Item> & {
   theme: DoobooTheme;
 }): ReactElement {
-  const GAP = 15;
-  const {FAB, FABItem, buttonSize = 'large', iconSize = 24} = styles ?? {};
+  const {
+    FAB,
+    FABItem,
+    buttonSize = 'large',
+    iconSize = 24,
+    gap = 20,
+  } = styles ?? {};
 
-  const spinValue = useRef<Animated.Value>(new Animated.Value(0));
-  const positionValue = useRef<Animated.Value>(new Animated.Value(0));
-  const FABHeight = useRef<number>(0);
+  const spinValue = useRef(new Animated.Value(0));
+  const positionValue = useRef(new Animated.Value(0));
+  const FABHeight = useRef(0);
 
   useLayoutEffect(() => {
     const config = {
@@ -79,10 +85,10 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
       FABItems?.map((_, idx) =>
         positionValue.current.interpolate({
           inputRange: [0, 1],
-          outputRange: [0, -1 * (idx + 1) * (FABHeight.current + GAP)],
+          outputRange: [0, -1 * (idx + 1) * (FABHeight.current + gap)],
         }),
       ),
-    [FABItems, FABHeight],
+    [FABItems, FABHeight, gap],
   );
 
   const onLayout = (e: LayoutChangeEvent): void => {

--- a/main/FAB/index.tsx
+++ b/main/FAB/index.tsx
@@ -1,4 +1,11 @@
-import {Animated, Easing, StyleProp, View, ViewStyle} from 'react-native';
+import {
+  Animated,
+  Easing,
+  LayoutChangeEvent,
+  StyleProp,
+  View,
+  ViewStyle,
+} from 'react-native';
 import {ButtonSize, IconButton} from '../IconButton';
 import {DoobooTheme, withTheme} from '../theme';
 import {Icon, IconName} from '../Icon';
@@ -46,10 +53,12 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
 }: FABProps<Item> & {
   theme: DoobooTheme;
 }): ReactElement {
+  const GAP = 15;
   const {FAB, FABItem, buttonSize = 'large', iconSize = 24} = styles ?? {};
 
-  const spinValue = useRef(new Animated.Value(0));
-  const positionValue = useRef(new Animated.Value(0));
+  const spinValue = useRef<Animated.Value>(new Animated.Value(0));
+  const positionValue = useRef<Animated.Value>(new Animated.Value(0));
+  const FABHeight = useRef<number>(0);
 
   useLayoutEffect(() => {
     const config = {
@@ -70,11 +79,15 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
       FABItems?.map((_, idx) =>
         positionValue.current.interpolate({
           inputRange: [0, 1],
-          outputRange: ['0%', `-${(idx + 1) * 80}%`],
+          outputRange: [0, -1 * (idx + 1) * (FABHeight.current + GAP)],
         }),
       ),
-    [FABItems],
+    [FABItems, FABHeight],
   );
+
+  const onLayout = (e: LayoutChangeEvent): void => {
+    FABHeight.current = e.nativeEvent.layout.height;
+  };
 
   return (
     <View
@@ -97,7 +110,6 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
             key={id}
             style={[
               {
-                margin: 10,
                 position: 'absolute',
                 transform: [{translateY: offsets[idx]}],
               },
@@ -118,6 +130,7 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
         );
       })}
       <Animated.View
+        onLayout={onLayout}
         style={[
           {
             transform: [
@@ -128,7 +141,6 @@ function FloatingActionButtons<Item extends FABItem = FABItem>({
                 }),
               },
             ],
-            margin: 10,
           },
           FAB,
         ]}


### PR DESCRIPTION
## Description

style fix.
before:
the gap between the FAB buttons are not the same across the environment.

after
1. change the unit for the gap. % => px
2. gap will be decided with the height of the FAB view

I checked IOS, Web, and Android environments.
Check below.

(ios)
https://user-images.githubusercontent.com/35381940/135742330-ce241049-4f54-42d1-a4dc-1b2444e63ad9.mov

(web)
https://user-images.githubusercontent.com/35381940/135742409-2073bf20-fe78-411a-801f-d6e6f0d29f9e.mov

(android)
https://user-images.githubusercontent.com/35381940/135743099-84e53125-93ff-4368-98d6-5013297dc733.mov



## Test Plan
check the demo. 

## Related Issues
[related Issue](https://github.com/dooboolab/dooboo-ui/issues/135#issue-1014072268)

## Tests


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
