### PR TITLE
feat: Add global fontFamily

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -2,6 +2,12 @@
 
 ## 0.1.35
 
+#### Feature
+
+- Add `setFontFamily` function to set global `fontFamily` (#138)
+
+#### Enhancement
+
 - Fix fallbackImage and loadingImage style (#127)
 
 ## 0.1.34

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.35-rc.3",
+  "version": "0.1.35-rc.5",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.1.35-rc.1",
+  "version": "0.1.35-rc.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/Typography/index.tsx
+++ b/main/Typography/index.tsx
@@ -9,6 +9,7 @@ import {
 } from './TypographyInverted';
 
 import React from 'react';
+import {Text} from 'react-native';
 
 export const Typography = {
   Title,

--- a/main/Typography/index.tsx
+++ b/main/Typography/index.tsx
@@ -8,6 +8,8 @@ import {
   InvertedTitle,
 } from './TypographyInverted';
 
+import React from 'react';
+
 export const Typography = {
   Title,
   Heading1,
@@ -24,4 +26,23 @@ export const TypographyInverted = {
   Heading3: InvertedHeading3,
   Body1: InvertedBody1,
   Body2: InvertedBody2,
+};
+
+export const setFontFamiliy = (fontFamily: string): void => {
+  const style = {
+    includeFontPadding: false,
+    fontFamily,
+  };
+
+  // @ts-ignore
+  let oldRender = Text.render;
+
+  // @ts-ignore
+  Text.render = (...args: any) => {
+    let origin = oldRender.call(this, ...args);
+
+    return React.cloneElement(origin, {
+      style: [style, origin.props.style],
+    });
+  };
 };


### PR DESCRIPTION
## Description

Adding default `fontFamily` in each `Text` component is frustrating. Add ability to set this globally.
Add `setFontFamiliy` function.


## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
