### PR TITLE
Add new props shouldImageRatioFixed to support image's own aspectRatio before render

### DIFF
--- a/main/NetworkImage/index.tsx
+++ b/main/NetworkImage/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   loadingSource?: ImageRequireSource | ReactElement;
   fallbackSource?: ImageRequireSource;
   imageProps?: Partial<ImageProps>;
+  shouldImageRatioFixed?: boolean;
 }
 
 const defaultImage = css({
@@ -44,9 +45,16 @@ function NetworkImage(props: Props): ReactElement {
 
   const logo = themeType === 'light' ? ArtifactsLogoLight : ArtifactsLogoDark;
 
-  const {style, url, imageProps, fallbackSource = logo} = props;
+  const {
+    style,
+    url,
+    imageProps,
+    fallbackSource = logo,
+    shouldImageRatioFixed = false,
+  } = props;
 
   const {image, loading, fallback} = props.styles ?? {};
+  const [imageRatio, setImageRatio] = useState(110 / 74);
 
   const loadingSource: ReactElement = isValidElement(props?.loadingSource) ? (
     props?.loadingSource
@@ -76,13 +84,19 @@ function NetworkImage(props: Props): ReactElement {
     }
   }, [url]);
 
+  useEffect(() => {
+    if (url && isValidSource) {
+      Image.getSize(url, (width, height) => {
+        setImageRatio(width / height);
+      });
+    }
+  }, [isValidSource, url]);
+
   return (
     <View
       style={[
-        {
-          justifyContent: 'center',
-          alignItems: 'center',
-        },
+        shouldImageRatioFixed && {aspectRatio: imageRatio},
+        {justifyContent: 'center', alignItems: 'center'},
         style,
       ]}
     >

--- a/main/__tests__/NetworkImage.test.tsx
+++ b/main/__tests__/NetworkImage.test.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import {createComponent, createTestProps} from '../../test/testUtils';
+
+import {NetworkImage} from '../../main';
+import {View} from 'react-native';
+import renderer from 'react-test-renderer';
+
+let props: any;
+let component: React.ReactElement;
+
+describe('[NetworkImage] render', () => {
+  beforeEach(() => {
+    props = createTestProps();
+
+    component = createComponent(<NetworkImage {...props} />);
+  });
+
+  it('should render without crashing', () => {
+    const rendered = renderer.create(component).toJSON();
+
+    expect(rendered).toMatchSnapshot();
+    expect(rendered).toBeTruthy();
+  });
+});

--- a/main/__tests__/__snapshots__/NetworkImage.test.tsx.snap
+++ b/main/__tests__/__snapshots__/NetworkImage.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[NetworkImage] render should render without crashing 1`] = `
+<View
+  style={
+    Array [
+      false,
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    resizeMethod="resize"
+    resizeMode="cover"
+    source={
+      Object {
+        "canInstrument": true,
+        "createTransformer": [Function],
+        "getCacheKey": [Function],
+        "process": [Function],
+      }
+    }
+    style={
+      Array [
+        Object {
+          "aspectRatio": 1.4864864864864864,
+          "height": "auto",
+          "maxHeight": "50%",
+          "width": "50%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;


### PR DESCRIPTION
## Description

Add new props `shouldImageRatioFixed`. 

This props will make easy to give an Image's aspectRatio without further works.

## Test Plan

N/A

## Related Issues

N/A

## Tests

I added the following tests:

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
