### PR TITLE
Fix the dark mode release from iOS background

### DIFF
--- a/packages/theme/useColorScheme.ts
+++ b/packages/theme/useColorScheme.ts
@@ -1,11 +1,17 @@
-import {Appearance, ColorSchemeName} from 'react-native';
+import {Appearance, ColorSchemeName, Platform} from 'react-native';
 import {useEffect, useState} from 'react';
 
 export const useColorScheme = (): ColorSchemeName => {
-  const [colorType, setColorType] = useState(Appearance.getColorScheme());
+  const deviceThemeType = Appearance.getColorScheme();
+  const [colorType, setColorType] = useState(deviceThemeType);
 
   useEffect(() => {
-    const listener = (): void => setColorType(Appearance.getColorScheme());
+    const listener = ({colorScheme}): void => {
+      const platformColorScheme =
+        Platform.OS === 'ios' ? Appearance.getColorScheme() : colorScheme;
+
+      setColorType(platformColorScheme);
+    };
 
     Appearance.addChangeListener(listener);
 

--- a/packages/theme/useColorScheme.ts
+++ b/packages/theme/useColorScheme.ts
@@ -2,13 +2,10 @@ import {Appearance, ColorSchemeName} from 'react-native';
 import {useEffect, useState} from 'react';
 
 export const useColorScheme = (): ColorSchemeName => {
-  const deviceThemeType = Appearance.getColorScheme();
-  const [colorType, setColorType] = useState(deviceThemeType);
+  const [colorType, setColorType] = useState(Appearance.getColorScheme());
 
   useEffect(() => {
-    const listener = ({colorScheme}): void => {
-      setColorType(colorScheme);
-    };
+    const listener = (): void => setColorType(Appearance.getColorScheme());
 
     Appearance.addChangeListener(listener);
 


### PR DESCRIPTION
## Description
I modified the release of dark mode in iOS background.
This is a bug in the addChangeListener, a method of the Appearance in react-native.
This is a bug that only happens in iOS. [Issue link](https://github.com/facebook/react-native/issues/28525)


Despite the dark theme, the color Scheme variable is initialized to light when switching to background.   
```ts
// File path: dooboo-ui/packages/theme/useColorScheme.ts

const listener = ({colorScheme}): void => {
   setColorType(colorScheme);
};
```

To solve this problem, I changed it to match the color by calling Appearance.getColorScheme() again when the listener is called.

### Before
https://user-images.githubusercontent.com/29420674/140264579-51a3fc65-01ab-4df6-adc4-52ac95b3cdba.mov

### After
https://user-images.githubusercontent.com/29420674/140264646-4f3b8d69-bc2e-4374-8bd3-c1fa4801d14a.mov


## Test Plan
N/A

## Related Issues
N/A

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
