### PR TITLE
Improve NetworkImage rendering time

### DIFF
--- a/main/NetworkImage/index.tsx
+++ b/main/NetworkImage/index.tsx
@@ -32,7 +32,7 @@ type Styles = {
 interface Props {
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
-  url: string;
+  url: string | undefined;
   loadingSource?: ImageRequireSource | ReactElement;
   fallbackSource?: ImageRequireSource;
   imageProps?: Partial<ImageProps>;
@@ -108,6 +108,10 @@ function NetworkImage(props: Props): ReactElement {
   );
 
   useEffect(() => {
+    if (!url) {
+      return;
+    }
+
     Image.getSize(
       url,
       (width, height) => {


### PR DESCRIPTION
## Description

After this [PR](https://github.com/dooboolab/dooboo-ui/pull/161) merged, Rendering time is quite longer than before. 
To improve this problem, I combined `useEffect` and add `useCallback` for memoization.  as a result, Rendering time is decreased about 20% more in my environment.


**** I renamed `shouldImageRatioFixed` into `shouldFixImageRatio`.

## Test Plan

N/A

## Related Issues

N/A

## Tests

I added the following tests:

To test render time, I used [Profiler API](https://reactjs.org/docs/profiler.html#gatsby-focus-wrapper).

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
