### PR TITLE
Fix network images overlapping when shoudFixImageRatio is true

### DIFF
--- a/main/NetworkImage/index.tsx
+++ b/main/NetworkImage/index.tsx
@@ -124,6 +124,10 @@ function NetworkImage(props: Props): ReactElement {
     );
   }, [isValidSource, url, shouldFixImageRatio]);
 
+  if (needLoading) {
+    return <View style={style}>{loadingSource}</View>;
+  }
+
   return (
     <View
       style={[
@@ -132,11 +136,9 @@ function NetworkImage(props: Props): ReactElement {
         style,
       ]}
     >
-      {!needLoading && isValidSource && renderImage()}
+      {isValidSource && renderImage()}
 
-      {!needLoading && !isValidSource && renderLoading()}
-
-      {needLoading && loadingSource}
+      {!isValidSource && renderLoading()}
     </View>
   );
 }


### PR DESCRIPTION
## Description

Fix network images overlapping when shoudFixImageRatio is true

The function of importing the size of the image is asynchronous, but the problem occurs because the render is already used first and then the size of the image is imported.

Bug



https://user-images.githubusercontent.com/29420674/140698848-3536e820-0fa5-4f00-a3c5-f58032668723.mov

## Test Plan

Test by changing the props of the shoulderFixImageRatio of the NetworkImage component to true.

## Related Issues
N/F

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
