### PR TITLE
Fix network image loading source style

### DIFF
--- a/main/NetworkImage/index.tsx
+++ b/main/NetworkImage/index.tsx
@@ -125,7 +125,11 @@ function NetworkImage(props: Props): ReactElement {
   }, [isValidSource, url, shouldFixImageRatio]);
 
   if (needLoading) {
-    return <View style={style}>{loadingSource}</View>;
+    return (
+      <View style={[{justifyContent: 'center', alignItems: 'center'}, style]}>
+        {loadingSource}
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
## Description
I'm sorry. It's my mistake.
The loading style of the network image component is missing that must be in the middle.
I'll look carefully. 😭 

https://user-images.githubusercontent.com/29420674/140762554-9cbd3e6b-b85f-43b6-80b7-98f2d7234b0c.mp4


## Test Plan
N/A

## Related Issues
N/A

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
