### PR TITLE
Fix a package name in lib/package.json

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -18,7 +18,7 @@
     "@emotion/react": ">=11.0.0",
     "react": ">=16.9",
     "react-native": ">=0.58",
-    "react-native-gestuer-handler": "*",
+    "react-native-gesture-handler": "*",
     "react-native-vector-icons": "*"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

couldn't complete the installation with the command 'expo install dooboo-ui'
and found something that looks like a possible cause.
if it's not a typo, please correct me. thank you.

```
> npm install --save dooboo-ui
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/react-native-gestuer-handler - Not found
npm ERR! 404 
npm ERR! 404  'react-native-gestuer-handler@*' is not in this registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

## Test Plan

N/A

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
