### PR TITLE
fix: add borderLeftWidth for LastElement button

### DIFF
--- a/main/ButtonGroup/index.tsx
+++ b/main/ButtonGroup/index.tsx
@@ -70,6 +70,7 @@ export function ButtonGroup<T>(props: Props<T>): React.ReactElement {
 
     const borderForLastElement = {
       ...fullWidthAndRadius,
+      borderLeftWidth: undefined,
       borderTopLeftRadius: undefined,
       borderBottomLeftRadius: undefined,
     };


### PR DESCRIPTION
## Description

In this Demo Docs(https://dooboo-ui.dooboolab.com/?path=/docs/components-buttongroup--page),
left-border-width of last button is thick than other buttons. So I fixed `const borderForLastElement`.


```jsx
const borderForLastElement = {
      ...fullWidthAndRadius,
      borderLeftWidth: undefined, // I fixed here.
      borderTopLeftRadius: undefined,
      borderBottomLeftRadius: undefined,
    };
```

Correct me, if I'm wrong.



## Test Plan

N/A

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.