### PR TITLE
Update docs of Accordion

### DIFF
--- a/docs/src/components/Accordion/Accordion.stories.mdx
+++ b/docs/src/components/Accordion/Accordion.stories.mdx
@@ -9,18 +9,18 @@ import Default from './index';
 
 ## Props
 
-|                 | necessary | types                   | default               |
-| --------------- | --------- | ----------------------- | --------------------- |
-| style           |           | ViewStyle               | `undefined`           |
-| styles          |           | Styles                  | `undefined`           |
-| data            | ✓         | array                   |                       |
-| shouldAnimate   |           | boolean                 | `true`                |
-| collapseOnStart |           | boolean                 | `true `               |
-| animDuration    |           | number                  | `300`                 |
-| activeOpacity   |           | number                  | `1`                   |
-| toggleElement   |           | React.ReactElement      | `default arrow image` |
-| renderTitle     |           | (string) => JSX.Element | `default wrapper`     |
-| renderBody      |           | (string) => JSX.Element | `default wrapper`     |
+|                 | necessary | types                                                                                                   | default               |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------- | --------------------- |
+| style           |           | ViewStyle                                                                                               | `undefined`           |
+| styles          |           | Styles                                                                                                  | `undefined`           |
+| data            | ✓         | Array<{<br/>&nbsp;&nbsp;&nbsp;&nbsp;title: string;<br/>&nbsp;&nbsp;&nbsp;&nbsp;bodies: string[];<br/>}> |                       |
+| shouldAnimate   |           | boolean                                                                                                 | `true`                |
+| collapseOnStart |           | boolean                                                                                                 | `true `               |
+| animDuration    |           | number                                                                                                  | `300`                 |
+| activeOpacity   |           | number                                                                                                  | `1`                   |
+| toggleElement   |           | React.ReactElement                                                                                      | `default arrow image` |
+| renderTitle     |           | (string) => JSX.Element                                                                                 | `default wrapper`     |
+| renderBody      |           | (string) => JSX.Element                                                                                 | `default wrapper`     |
 
 ## Installation
 
@@ -36,43 +36,16 @@ import {Accordion} from 'dooboo-ui';
 const Default = (): React.ReactElement => {
   const data = [
     {
-      title: {
-        name: <StyledTitle>Default-title-01</StyledTitle>,
-      },
-      bodies: [
-        {
-          name: <StyledItem>Default body01</StyledItem>,
-        },
-        {
-          name: <StyledItem>Default body02</StyledItem>,
-        },
-      ],
+      title: 'Default-title-01',
+      bodies: ['Default body01', 'Default body02'],
     },
     {
-      title: {
-        name: <StyledTitle>Default-title-02</StyledTitle>,
-      },
-      bodies: [
-        {
-          name: <StyledItem>Default body01</StyledItem>,
-        },
-        {
-          name: <StyledItem>Default body02</StyledItem>,
-        },
-      ],
+      title: 'Default-title-02',
+      bodies: ['Default body01', 'Default body02'],
     },
     {
-      title: {
-        name: <StyledTitle>Default-title-03</StyledTitle>,
-      },
-      bodies: [
-        {
-          name: <StyledItem>Default body01</StyledItem>,
-        },
-        {
-          name: <StyledItem>Default body02</StyledItem>,
-        },
-      ],
+      title: 'Default-title-03',
+      bodies: ['Default body01', 'Default body02'],
     },
   ];
 

--- a/docs/src/components/Accordion/Accordion.stories.mdx
+++ b/docs/src/components/Accordion/Accordion.stories.mdx
@@ -9,18 +9,18 @@ import Default from './index';
 
 ## Props
 
-|                 | necessary | types                                                                                                   | default               |
-| --------------- | --------- | ------------------------------------------------------------------------------------------------------- | --------------------- |
-| style           |           | ViewStyle                                                                                               | `undefined`           |
-| styles          |           | Styles                                                                                                  | `undefined`           |
-| data            | ✓         | Array<{<br/>&nbsp;&nbsp;&nbsp;&nbsp;title: string;<br/>&nbsp;&nbsp;&nbsp;&nbsp;bodies: string[];<br/>}> |                       |
-| shouldAnimate   |           | boolean                                                                                                 | `true`                |
-| collapseOnStart |           | boolean                                                                                                 | `true `               |
-| animDuration    |           | number                                                                                                  | `300`                 |
-| activeOpacity   |           | number                                                                                                  | `1`                   |
-| toggleElement   |           | React.ReactElement                                                                                      | `default arrow image` |
-| renderTitle     |           | (string) => JSX.Element                                                                                 | `default wrapper`     |
-| renderBody      |           | (string) => JSX.Element                                                                                 | `default wrapper`     |
+|                 | necessary | types                   | default               |
+| --------------- | --------- | ----------------------- | --------------------- |
+| style           |           | ViewStyle               | `undefined`           |
+| styles          |           | Styles                  | `undefined`           |
+| data            | ✓         | AccordionListType       |                       |
+| shouldAnimate   |           | boolean                 | `true`                |
+| collapseOnStart |           | boolean                 | `true `               |
+| animDuration    |           | number                  | `300`                 |
+| activeOpacity   |           | number                  | `1`                   |
+| toggleElement   |           | React.ReactElement      | `default arrow image` |
+| renderTitle     |           | (string) => JSX.Element | `default wrapper`     |
+| renderBody      |           | (string) => JSX.Element | `default wrapper`     |
 
 ## Installation
 
@@ -31,10 +31,10 @@ yarn add dooboo-ui
 ## Usage
 
 ```javascript
-import {Accordion} from 'dooboo-ui';
+import {Accordion, AccordionListType} from 'dooboo-ui';
 
 const Default = (): React.ReactElement => {
-  const data = [
+  const data: AccordionListType = [
     {
       title: 'Default-title-01',
       bodies: ['Default body01', 'Default body02'],


### PR DESCRIPTION
## Description

The description of Accordion in documentation has explained the type of prop `data` as just `array`, and used wrong example of prop `data`. The type of prop `data` actually is:
```typescript
Array<{
  title: string;
  bodies: string[];
}>
```
The previous description could not explain enough about prop `data`, in my opinion. So I updated documentation of prop `data`, and `data` example in usage.

## Test Plan

N/A

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
