### PR TITLE
Fix default expand is not working bug in [Accordion]

### DIFF
--- a/main/__tests__/Accordion.test.tsx
+++ b/main/__tests__/Accordion.test.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement} from 'react';
-import {RenderAPI, fireEvent, render} from '@testing-library/react-native';
+import {RenderAPI, act, fireEvent, render} from '@testing-library/react-native';
 import {createComponent, createTestProps} from '../../test/testUtils';
 
 import {Accordion} from '../../main';
@@ -77,6 +77,34 @@ describe('[Accordion] render test', () => {
     const json = testingLib.toJSON();
 
     expect(json).toMatchSnapshot();
+  });
+
+  describe('[Accordion] - Change default value', () => {
+    it('should expand the accordion by default when collapseOnStart props is false', () => {
+      props = createTestProps({
+        collapseOnStart: false,
+        data: data,
+      });
+
+      const comp = createComponent(<Accordion {...props} />);
+
+      testingLib = render(comp);
+
+      const body0 = testingLib.queryByTestId('body_0');
+
+      act(() => {
+        fireEvent(body0, 'layout', {
+          nativeEvent: {
+            layout: {
+              height: 170,
+            },
+          },
+        });
+      });
+
+      expect(body0.props.style.height).toBeDefined();
+      expect(body0.props.accessibilityState.expanded).toBeTruthy();
+    });
   });
 });
 

--- a/main/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/main/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -106,6 +106,11 @@ exports[`[Accordion] render test should adjust duration of animation depends on 
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -318,6 +323,11 @@ exports[`[Accordion] render test should adjust duration of animation depends on 
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -530,6 +540,11 @@ exports[`[Accordion] render test should adjust duration of animation depends on 
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -757,6 +772,11 @@ exports[`[Accordion] render test should operate animation when shouldAnimate pro
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -969,6 +989,11 @@ exports[`[Accordion] render test should operate animation when shouldAnimate pro
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -1181,6 +1206,11 @@ exports[`[Accordion] render test should operate animation when shouldAnimate pro
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -1408,6 +1438,11 @@ exports[`[Accordion] render test should render collapsed when collapseOnStart pr
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -1620,6 +1655,11 @@ exports[`[Accordion] render test should render collapsed when collapseOnStart pr
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -1832,6 +1872,11 @@ exports[`[Accordion] render test should render collapsed when collapseOnStart pr
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -2030,6 +2075,11 @@ exports[`[Accordion] render test should render without crashing 1`] = `
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -2213,6 +2263,11 @@ exports[`[Accordion] render test should render without crashing 1`] = `
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {
@@ -2396,6 +2451,11 @@ exports[`[Accordion] render test should render without crashing 1`] = `
       </View>
     </View>
     <View
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       onLayout={[Function]}
       style={
         Object {


### PR DESCRIPTION
## Description

I have found a bug that caused [Accordion] component did not expand by default when collapseOnStart is false.
Previously, I changed bodyHeight value React.useState to React.useRef for [this work](https://github.com/dooboolab/dooboo-ui/pull/108#discussion_r765427352). I think it's wrong and it's my mistake. I'm sorry.

On this PR, I fixed a bug and worked additional jobs for guarantee it.
1. I added a test code. (but it's not good enough...) I got an idea from this [reference](https://reactnative.dev/docs/testing-overview#testing-user-interactions) and write test code using [accessibility helpers](https://reactnative.dev/docs/accessibility#accessibility-properties). also i'm going to keep updating the test code and accessibility properties.
2. I rewrote code to adjust bodyContainer height using Animated.Value.interpolate() and same targetValue as toggleElement.

## Test Plan

I added a test code for change default value at [main/__tests__/Accordion.test.tsx](https://github.com/dooboolab/dooboo-ui/compare/main...luke-hanwook:fix/Accordion?expand=1#diff-bf3073835a6af2693628412d210189027502ae4c81955ec925695333c01c5b7e). and you can run test.

## Related Issues

#108 

## Tests

I added the following tests:
[Accordion] - Change default value should expand the accordion by default when collapseOnStart props is false.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
