### PR TITLE
Add export type definition in [Accordion]

### DIFF
--- a/main/Accordion/Accordion.tsx
+++ b/main/Accordion/Accordion.tsx
@@ -29,7 +29,7 @@ export interface AccordionBaseProps<T> {
 
 export type AccordionListType = AccordionData[];
 
-type AccordionProps = AccordionBaseProps<AccordionListType>;
+export type AccordionProps = AccordionBaseProps<AccordionListType>;
 
 const Accordion: FC<AccordionProps> = (props) => {
   const {

--- a/main/Accordion/index.tsx
+++ b/main/Accordion/index.tsx
@@ -1,6 +1,5 @@
-import Accordion, {AccordionListType} from './Accordion';
-
+import Accordion, {AccordionProps, AccordionListType} from './Accordion';
 import {AccordionData} from './AccordionItem';
 
 export {Accordion};
-export type {AccordionData, AccordionListType};
+export type {AccordionProps, AccordionData, AccordionListType};


### PR DESCRIPTION
## Description

I added the `AccordionProps` to the export type definition.
It's a basic but i missed it by mistake.
I think it's very useful when implementing a wrapped [Accordion] component.

## Test Plan

N/A

## Related Issues

#108 

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
