### PR TITLE
fix: animate translateX inputRange is fixed on web

### DIFF
--- a/main/SwitchToggle/index.tsx
+++ b/main/SwitchToggle/index.tsx
@@ -1,10 +1,4 @@
-import {
-  Animated,
-  Platform,
-  StyleProp,
-  TouchableOpacity,
-  ViewStyle,
-} from 'react-native';
+import {Animated, StyleProp, TouchableOpacity, ViewStyle} from 'react-native';
 import React, {ReactElement, useEffect, useState} from 'react';
 
 import styled from '@emotion/native';
@@ -128,10 +122,7 @@ export function SwitchToggle(props: Props): ReactElement {
           transform: [
             {
               translateX: animXValue.interpolate({
-                inputRange: Platform.select({
-                  web: [-0.2, 2.4],
-                  default: [0, 1],
-                }),
+                inputRange: [0, 1],
                 outputRange: [
                   circlePosXStart as string | number,
                   circlePosXEnd as string | number,


### PR DESCRIPTION
## Description

No more adhoc coded needed on `translateX inputRange` on web.
Looks like it's been fixed in RN web 0.18+.

## Test Plan

Previously,
<img width="119" alt="Screen Shot 2022-08-09 at 1 08 22 AM" src="https://user-images.githubusercontent.com/27461460/183465330-a40d5541-4088-42b3-9819-885beb2892d8.png">

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
