### PR TITLE
feat(enh): edit text colors and cleanup codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
   "prettier.configPath": ".prettierrc.js",
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": [
-    "Progressbar"
+    "Progressbar",
+    "unhovered"
   ],
 }

--- a/main/EditText/__tests__/EditText.test.tsx
+++ b/main/EditText/__tests__/EditText.test.tsx
@@ -1,12 +1,14 @@
+import type {EditTextProps, EditTextStatus} from '..';
 import {act, fireEvent, render} from '@testing-library/react-native';
 
 import {EditText} from '..';
-import type {EditTextProps} from '..';
 import RNWebHooks from 'react-native-web-hooks';
 import React from 'react';
 import type {ReactElement} from 'react';
 import type {RenderAPI} from '@testing-library/react-native';
+import {Text} from 'react-native';
 import {createComponent} from '../../../test/testUtils';
+import {light} from '@dooboo-ui/theme';
 
 jest.mock('react-native-web-hooks', () => ({
   useHover: () => false,
@@ -29,7 +31,7 @@ describe('[EditText]', () => {
       jest.spyOn(RNWebHooks, 'useHover').mockImplementation(() => true);
     });
 
-    describe('labeText', () => {
+    describe('label', () => {
       it('should render label text', async () => {
         testingLib = render(component({label: 'label text'}));
 
@@ -42,15 +44,46 @@ describe('[EditText]', () => {
         testingLib = render(
           component({
             label: 'label text',
-            styles: {
-              label: {color: 'green'},
+            colors: {
+              basic: 'blue',
+              placeholder: 'green',
+              disabled: 'red',
+              error: 'yellow',
+              focused: 'purple',
+              hovered: 'orange',
             },
           }),
         );
 
         const label = testingLib.getByText('label text');
 
-        expect(label).toHaveStyle({color: 'green'});
+        expect(label).toHaveStyle({color: 'orange'});
+      });
+
+      it('should render custom label style', async () => {
+        const renderCustomLabel = (status: EditTextStatus): ReactElement => {
+          return (
+            <Text
+              style={{
+                color: 'blue',
+                fontSize: 12,
+                fontWeight: 'bold',
+              }}
+            >
+              Custom label
+            </Text>
+          );
+        };
+
+        testingLib = render(
+          component({
+            label: renderCustomLabel,
+          }),
+        );
+
+        const label = testingLib.getByText('Custom label');
+
+        expect(label).toBeTruthy();
       });
 
       describe('unhovered', () => {
@@ -63,13 +96,19 @@ describe('[EditText]', () => {
             component({
               testID: 'INPUT_TEST',
               label: 'label text',
-              styles: {
-                label: {color: 'green'},
+              colors: {
+                basic: 'blue',
+                placeholder: 'green',
+                disabled: 'red',
+                error: 'yellow',
+                focused: 'purple',
+                hovered: 'orange',
               },
             }),
           );
 
           const input = testingLib.getByTestId('INPUT_TEST');
+          expect(input).toHaveStyle({color: 'green'});
 
           act(() => {
             input.props.onFocus();
@@ -77,7 +116,7 @@ describe('[EditText]', () => {
 
           const label = testingLib.getByText('label text');
 
-          expect(label).toHaveStyle({color: 'green'});
+          expect(label).toHaveStyle({color: 'purple'});
         });
 
         it('should render error element when provided', async () => {
@@ -105,7 +144,148 @@ describe('[EditText]', () => {
         });
       });
     });
+  });
 
+  describe('layout', () => {
+    it('should render [direction] row', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          direction: 'row',
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+      const container = testingLib.getByTestId('container');
+
+      expect(input).toBeTruthy();
+
+      expect(container).toHaveStyle({flexDirection: 'row'});
+    });
+
+    it('should render [decoration] boxed', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          decoration: 'boxed',
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+      const container = testingLib.getByTestId('container');
+
+      expect(input).toBeTruthy();
+
+      expect(container).toHaveStyle({borderWidth: 1});
+    });
+  });
+
+  describe('input', () => {
+    it('should trigger text changes', () => {
+      const CHANGE_TEXT = 'content';
+      const mockedFn = jest.fn();
+
+      const onChangeTextMock = (str: string): void => {
+        mockedFn(str);
+      };
+
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          editable: false,
+          onChangeText: onChangeTextMock,
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+
+      expect(input).toBeTruthy();
+
+      fireEvent.changeText(input, CHANGE_TEXT);
+
+      expect(mockedFn).toBeCalledWith(CHANGE_TEXT);
+    });
+
+    it('should have value', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          value: 'text123',
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+
+      expect(input).toBeTruthy();
+
+      expect(input).toHaveProp('value', 'text123');
+    });
+
+    it('should have render counter', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          value: 'text123',
+          maxLength: 100,
+        }),
+      );
+
+      const counter = testingLib.getByText('7/100');
+
+      expect(counter).toBeTruthy();
+    });
+
+    it('should have render custom error', () => {
+      const renderCustomError = (): ReactElement => <Text>custom error</Text>;
+
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          value: 'text123',
+          error: renderCustomError,
+        }),
+      );
+
+      const error = testingLib.getByText('custom error');
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe('disabled', () => {
+    it('should render [default] disabled style', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          editable: false,
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+
+      expect(input).toBeTruthy();
+
+      expect(input).toHaveStyle({color: light.text.disabled});
+    });
+
+    it('should render [custom] disabled style', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          colors: {disabled: 'yellow'},
+          editable: false,
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+
+      expect(input).toBeTruthy();
+
+      expect(input).toHaveStyle({color: 'yellow'});
+    });
+  });
+
+  describe('focus', () => {
     it('should trigger `onFocus`', async () => {
       testingLib = render(
         component({
@@ -119,6 +299,26 @@ describe('[EditText]', () => {
       expect(input).toBeTruthy();
 
       fireEvent(input, 'focus');
+
+      expect(input).toHaveStyle({color: light.text.default});
+    });
+
+    it('should trigger `onFocus` and render custom color', async () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+          onFocus: jest.fn(),
+          colors: {focused: 'yellow'},
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+
+      expect(input).toBeTruthy();
+
+      fireEvent(input, 'focus');
+
+      expect(input).toHaveStyle({color: 'yellow'});
     });
 
     describe('onBlur (focused === false)', () => {
@@ -127,6 +327,7 @@ describe('[EditText]', () => {
           component({
             onBlur: () => {},
             testID: 'INPUT_TEST',
+            colors: {placeholder: 'green'},
           }),
         );
 
@@ -135,21 +336,8 @@ describe('[EditText]', () => {
         expect(input).toBeTruthy();
 
         fireEvent(input, 'blur');
-      });
 
-      it('should trigger blur with errorText', async () => {
-        testingLib = render(
-          component({
-            testID: 'INPUT_TEST',
-            error: 'error text',
-          }),
-        );
-
-        const input = testingLib.getByTestId('INPUT_TEST');
-
-        expect(input).toBeTruthy();
-
-        fireEvent(input, 'blur');
+        expect(input).toHaveStyle({color: 'green'});
       });
     });
   });

--- a/main/EditText/__tests__/EditText.test.tsx
+++ b/main/EditText/__tests__/EditText.test.tsx
@@ -1,7 +1,7 @@
-import type {EditTextProps, EditTextStatus} from '..';
 import {act, fireEvent, render} from '@testing-library/react-native';
 
 import {EditText} from '..';
+import type {EditTextProps} from '..';
 import RNWebHooks from 'react-native-web-hooks';
 import React from 'react';
 import type {ReactElement} from 'react';
@@ -61,7 +61,7 @@ describe('[EditText]', () => {
       });
 
       it('should render custom label style', async () => {
-        const renderCustomLabel = (status: EditTextStatus): ReactElement => {
+        const renderCustomLabel = (): ReactElement => {
           return (
             <Text
               style={{

--- a/main/EditText/__tests__/EditText.test.tsx
+++ b/main/EditText/__tests__/EditText.test.tsx
@@ -21,11 +21,7 @@ describe('[EditText]', () => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
 
   beforeAll(() => {
-    testingLib = render(
-      component({
-        autoCapitalize: 'words',
-      }),
-    );
+    testingLib = render(component());
   });
 
   describe('hovered', () => {
@@ -35,11 +31,7 @@ describe('[EditText]', () => {
 
     describe('labeText', () => {
       it('should render label text', async () => {
-        testingLib = render(
-          component({
-            label: 'label text',
-          }),
-        );
+        testingLib = render(component({label: 'label text'}));
 
         const label = testingLib.getByText('label text');
 
@@ -51,17 +43,14 @@ describe('[EditText]', () => {
           component({
             label: 'label text',
             styles: {
-              label: {
-                color: 'green',
-              },
+              label: {color: 'green'},
             },
           }),
         );
 
         const label = testingLib.getByText('label text');
-        const labelTextStyle = label.props.style;
 
-        expect(labelTextStyle).toBeTruthy();
+        expect(label).toHaveStyle({color: 'green'});
       });
 
       describe('unhovered', () => {
@@ -75,9 +64,7 @@ describe('[EditText]', () => {
               testID: 'INPUT_TEST',
               label: 'label text',
               styles: {
-                label: {
-                  color: 'green',
-                },
+                label: {color: 'green'},
               },
             }),
           );
@@ -90,9 +77,7 @@ describe('[EditText]', () => {
 
           const label = testingLib.getByText('label text');
 
-          const unhoveredTextStyle = label.props.style[2];
-
-          expect(unhoveredTextStyle).toEqual({color: 'green'});
+          expect(label).toHaveStyle({color: 'green'});
         });
 
         it('should render error element when provided', async () => {

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -1,4 +1,4 @@
-import type {FC, LegacyRef, ReactElement} from 'react';
+import type {FC, LegacyRef, ReactElement, ReactNode} from 'react';
 import {Platform, Text, TextInput, View} from 'react-native';
 import React, {useRef, useState} from 'react';
 import type {
@@ -134,7 +134,6 @@ export const EditText: FC<EditTextProps> = (props) => {
     : colors.placeholder || theme.text.placeholder;
 
   // Default label placeholder color has different value compared to default input placeholder color
-
   const labelPlaceholderColor = defaultColor ===
     (colors.placeholder || theme.text.placeholder) && {
     color: colors.placeholder || theme.text.disabled,
@@ -150,15 +149,20 @@ export const EditText: FC<EditTextProps> = (props) => {
     ? 'focused'
     : 'basic';
 
-  return (
-    <View
-      testID="edit-text"
-      ref={Platform.select({web: ref, default: undefined})}
-      style={[
-        {alignSelf: 'stretch', padding: 12, flexDirection: 'column'},
-        style,
-      ]}
-    >
+  const renderLabel = (): ReactElement | null => {
+    return typeof label === 'string' ? (
+      <Text
+        style={[{color: defaultColor}, labelPlaceholderColor, styles?.label]}
+      >
+        {label}
+      </Text>
+    ) : label ? (
+      label(status)
+    ) : null;
+  };
+
+  const renderContainer = (children: ReactNode): ReactElement => {
+    return (
       <View
         testID="container"
         style={[
@@ -179,84 +183,102 @@ export const EditText: FC<EditTextProps> = (props) => {
           styles?.container,
         ]}
       >
-        {typeof label === 'string' ? (
-          <Text
-            style={[
-              {color: defaultColor},
-              labelPlaceholderColor,
-              styles?.label,
-            ]}
-          >
-            {label}
-          </Text>
-        ) : label ? (
-          label(status)
-        ) : null}
-        <TextInput
-          testID={testID}
-          ref={inputRef}
-          autoCapitalize={autoCapitalize}
-          secureTextEntry={secureTextEntry}
-          style={[
-            // Stretch input in order to make remaining space clickable
-            {flex: 1, alignSelf: 'stretch'},
-            // @ts-ignore
-            Platform.OS === 'web' && {outlineWidth: 0},
-            direction === 'column' ? {paddingTop: 12} : {paddingLeft: 12},
-            {color: defaultColor},
-            styles?.input,
-          ]}
-          editable={editable}
-          onFocus={(e) => {
-            setFocused(true);
-            onFocus?.(e);
-          }}
-          onBlur={(e) => {
-            setFocused(false);
-            onBlur?.(e);
-          }}
-          multiline={multiline}
-          maxLength={maxLength}
-          value={value}
-          placeholder={placeholder}
-          placeholderTextColor={placeholderColor || theme.text.placeholder}
-          onChange={onChange}
-          onChangeText={onChangeText}
-          onSubmitEditing={onSubmitEditing}
-          {...textInputProps}
-        />
-
-        {maxLength ? (
-          <Text
-            style={[
-              {
-                position: 'absolute',
-                color: theme.text.placeholder,
-                alignSelf: 'flex-end',
-                fontSize: 12,
-                bottom: -24,
-              },
-              styles?.counter,
-            ]}
-          >{`${value.length}/${maxLength}`}</Text>
-        ) : null}
+        {children}
       </View>
+    );
+  };
 
-      {error ? (
-        typeof error === 'string' ? (
-          <Text
-            style={[
-              {color: theme.text.validation},
-              {marginTop: 8, marginHorizontal: 10},
-              styles?.error,
-            ]}
-          >
-            {error}
-          </Text>
-        ) : (
-          error?.(status)
-        )
-      ) : null}
+  const renderInput = (): ReactElement => {
+    return (
+      <TextInput
+        testID={testID}
+        ref={inputRef}
+        autoCapitalize={autoCapitalize}
+        secureTextEntry={secureTextEntry}
+        style={[
+          // Stretch input in order to make remaining space clickable
+          {flex: 1, alignSelf: 'stretch'},
+          // @ts-ignore
+          Platform.OS === 'web' && {outlineWidth: 0},
+          direction === 'column' ? {paddingTop: 12} : {paddingLeft: 12},
+          {color: defaultColor},
+          styles?.input,
+        ]}
+        editable={editable}
+        onFocus={(e) => {
+          setFocused(true);
+          onFocus?.(e);
+        }}
+        onBlur={(e) => {
+          setFocused(false);
+          onBlur?.(e);
+        }}
+        multiline={multiline}
+        maxLength={maxLength}
+        value={value}
+        placeholder={placeholder}
+        placeholderTextColor={placeholderColor || theme.text.placeholder}
+        onChange={onChange}
+        onChangeText={onChangeText}
+        onSubmitEditing={onSubmitEditing}
+        {...textInputProps}
+      />
+    );
+  };
+
+  const renderError = (): ReactElement | null => {
+    return error ? (
+      typeof error === 'string' ? (
+        <Text
+          style={[
+            {color: theme.text.validation},
+            {marginTop: 8, marginHorizontal: 10},
+            styles?.error,
+          ]}
+        >
+          {error}
+        </Text>
+      ) : (
+        error?.(status)
+      )
+    ) : null;
+  };
+
+  const renderCounter = (): ReactElement | null => {
+    return maxLength ? (
+      <Text
+        style={[
+          {
+            position: 'absolute',
+            color: theme.text.placeholder,
+            alignSelf: 'flex-end',
+            fontSize: 12,
+            bottom: -24,
+          },
+          styles?.counter,
+        ]}
+      >{`${value.length}/${maxLength}`}</Text>
+    ) : null;
+  };
+
+  return (
+    <View
+      testID="edit-text"
+      ref={Platform.select({web: ref, default: undefined})}
+      style={[
+        {alignSelf: 'stretch', padding: 12, flexDirection: 'column'},
+        style,
+      ]}
+    >
+      {renderContainer(
+        <>
+          {renderLabel()}
+          {renderInput()}
+          {renderCounter()}
+        </>,
+      )}
+
+      {renderError()}
     </View>
   );
 };

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -24,6 +24,7 @@ export type EditTextStatus =
   | 'focused'
   | 'hovered'
   | 'basic';
+
 type RenderType = (stats: EditTextStatus) => ReactElement;
 
 export type EditTextProps = {
@@ -71,6 +72,15 @@ export type EditTextProps = {
     | 'onSubmitEditing'
     | 'maxLength'
   >;
+
+  colors?: {
+    basic?: string;
+    disabled?: string;
+    error?: string;
+    focused?: string;
+    hovered?: string;
+    placeholder?: string;
+  };
 };
 
 export const EditText: FC<EditTextProps> = (props) => {
@@ -97,6 +107,7 @@ export const EditText: FC<EditTextProps> = (props) => {
     editable = true,
     direction = 'column',
     decoration = 'underline',
+    colors = {},
   } = props;
 
   const {theme} = useTheme();
@@ -104,28 +115,26 @@ export const EditText: FC<EditTextProps> = (props) => {
   const [focused, setFocused] = useState(false);
   const ref = useRef<View>(null);
   const hovered = useHover(ref);
-  // `focused` or `hovered` has less priority than `error`
-  const focusedOrHovered = (focused || hovered) && !error;
 
   const defaultContainerStyle: ViewStyle = {
     flexDirection: direction,
   };
 
-  const defaultInputColor = !editable
-    ? theme.text.disabled
+  const defaultColor = !editable
+    ? colors.disabled || theme.text.disabled
     : error
-    ? theme.text.validation
-    : focusedOrHovered
-    ? theme.text.default
-    : theme.text.placeholder;
+    ? colors.error || theme.text.validation
+    : focused
+    ? colors.focused || theme.text.default
+    : hovered
+    ? colors.hovered
+    : value
+    ? colors.basic || theme.text.default
+    : colors.placeholder || theme.text.placeholder;
 
-  const defaultLabelColor = !editable
-    ? theme.text.disabled
-    : error
-    ? theme.text.validation
-    : focusedOrHovered
-    ? theme.text.default
-    : theme.text.placeholder;
+  // Default label placeholder color has different value compared to default input placeholder color
+  const isPlaceholderColor =
+    defaultColor === (colors.placeholder || theme.text.placeholder);
 
   const status: EditTextStatus = !editable
     ? 'disabled'
@@ -153,7 +162,7 @@ export const EditText: FC<EditTextProps> = (props) => {
           {
             flexDirection: direction,
             alignItems: direction === 'row' ? 'center' : 'flex-start',
-            borderColor: defaultInputColor,
+            borderColor: defaultColor,
             paddingVertical: 12,
             paddingHorizontal: 10,
           },
@@ -166,9 +175,9 @@ export const EditText: FC<EditTextProps> = (props) => {
         {typeof label === 'string' ? (
           <Text
             style={[
-              {color: defaultLabelColor},
-              focusedOrHovered && {
-                color: theme.text.default,
+              {color: defaultColor},
+              !!isPlaceholderColor && {
+                color: colors.placeholder || theme.text.disabled,
               },
               styles?.label,
             ]}
@@ -189,7 +198,7 @@ export const EditText: FC<EditTextProps> = (props) => {
             // @ts-ignore
             Platform.OS === 'web' && {outlineWidth: 0},
             direction === 'column' ? {paddingTop: 12} : {paddingLeft: 12},
-            {color: defaultInputColor},
+            {color: defaultColor},
             styles?.input,
           ]}
           editable={editable}

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -128,7 +128,7 @@ export const EditText: FC<EditTextProps> = (props) => {
     : focused
     ? colors.focused || theme.text.default
     : hovered
-    ? colors.hovered
+    ? colors.hovered || theme.text.default
     : value
     ? colors.basic || theme.text.default
     : colors.placeholder || theme.text.placeholder;
@@ -219,7 +219,7 @@ export const EditText: FC<EditTextProps> = (props) => {
           maxLength={maxLength}
           value={value}
           placeholder={placeholder}
-          placeholderTextColor={theme.text.placeholder || placeholderColor}
+          placeholderTextColor={placeholderColor || theme.text.placeholder}
           onChange={onChange}
           onChangeText={onChangeText}
           onSubmitEditing={onSubmitEditing}

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -129,8 +129,6 @@ export const EditText: FC<EditTextProps> = (props) => {
     ? colors.focused || theme.text.default
     : hovered
     ? colors.hovered || theme.text.default
-    : value
-    ? colors.basic || theme.text.default
     : colors.placeholder || theme.text.placeholder;
 
   // Default label placeholder color has different value compared to default input placeholder color

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -16,6 +16,7 @@ type Styles = {
   label?: StyleProp<TextStyle>;
   input?: StyleProp<TextStyle>;
   error?: StyleProp<TextStyle>;
+  counter?: StyleProp<TextStyle>;
 };
 
 export type EditTextStatus =
@@ -133,8 +134,11 @@ export const EditText: FC<EditTextProps> = (props) => {
     : colors.placeholder || theme.text.placeholder;
 
   // Default label placeholder color has different value compared to default input placeholder color
-  const isPlaceholderColor =
-    defaultColor === (colors.placeholder || theme.text.placeholder);
+
+  const labelPlaceholderColor = defaultColor ===
+    (colors.placeholder || theme.text.placeholder) && {
+    color: colors.placeholder || theme.text.disabled,
+  };
 
   const status: EditTextStatus = !editable
     ? 'disabled'
@@ -162,7 +166,10 @@ export const EditText: FC<EditTextProps> = (props) => {
           {
             flexDirection: direction,
             alignItems: direction === 'row' ? 'center' : 'flex-start',
-            borderColor: defaultColor,
+            // Default border color follows placeholder color for the label.
+            borderColor: labelPlaceholderColor
+              ? labelPlaceholderColor.color
+              : defaultColor,
             paddingVertical: 12,
             paddingHorizontal: 10,
           },
@@ -176,9 +183,7 @@ export const EditText: FC<EditTextProps> = (props) => {
           <Text
             style={[
               {color: defaultColor},
-              !!isPlaceholderColor && {
-                color: colors.placeholder || theme.text.disabled,
-              },
+              labelPlaceholderColor,
               styles?.label,
             ]}
           >
@@ -223,13 +228,16 @@ export const EditText: FC<EditTextProps> = (props) => {
 
         {maxLength ? (
           <Text
-            style={{
-              position: 'absolute',
-              color: theme.text.placeholder,
-              alignSelf: 'flex-end',
-              fontSize: 14,
-              bottom: -28,
-            }}
+            style={[
+              {
+                position: 'absolute',
+                color: theme.text.placeholder,
+                alignSelf: 'flex-end',
+                fontSize: 12,
+                bottom: -24,
+              },
+              styles?.counter,
+            ]}
           >{`${value.length}/${maxLength}`}</Text>
         ) : null}
       </View>

--- a/main/__tests__/EditTextLegacy.test.tsx
+++ b/main/__tests__/EditTextLegacy.test.tsx
@@ -476,7 +476,7 @@ describe('[EditTextLegacy]', () => {
       });
     });
 
-    //? Below tests is emitting console error but this is expeted
+    //? Below tests is emitting console error but this is expected
     describe('web', () => {
       beforeAll(() => {
         jest.mock('react-native/Libraries/Utilities/Platform', () => ({


### PR DESCRIPTION
## Description
Followed by #223, add `colors` props and cover tests.

Making styles customizable just to change colors for different statuses is complicated.
Exposing [colors] props for each status make it easier.

## Tests

Cover tests on expected styles and interaction.

<img width="240" alt="Screenshot 2023-01-08 at 2 23 59 PM" src="https://user-images.githubusercontent.com/27461460/211181799-d55e08fa-6805-40cf-bd42-4a62892656d7.png">


The above test structures look better instead of pushing all tests inside `main/__assets__`. Looking forward to refactoring them.


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails. You can run `yarn test -u` to update snapshots if needed.
- [x] I am willing to follow-up on review comments in a timely manner.
