### PR TITLE
refactor: [EditText] default styles and focusable event

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Check out [dooboo-ui.dooboolab.com](https://dooboo-ui.dooboolab.com)
 
 Hosted in [github pages](https://dooboolab.github.io/dooboo-ui)
 
+> `Documentation` is not identical to `Demo`. `Demo` is just a playground whereas `documentation` is for the customers.
+
 ## Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with

--- a/main/components/EditText/__tests__/EditText.test.tsx
+++ b/main/components/EditText/__tests__/EditText.test.tsx
@@ -32,7 +32,7 @@ describe('[EditText]', () => {
     });
 
     describe('label', () => {
-      it('should render label text', async () => {
+      it('renders label text', async () => {
         testingLib = render(component({label: 'label text'}));
 
         const label = testingLib.getByText('label text');
@@ -40,7 +40,7 @@ describe('[EditText]', () => {
         expect(label).toBeTruthy();
       });
 
-      it('should render label style', async () => {
+      it('renders label style', async () => {
         testingLib = render(
           component({
             label: 'label text',
@@ -60,7 +60,7 @@ describe('[EditText]', () => {
         expect(label).toHaveStyle({color: 'orange'});
       });
 
-      it('should render custom label style', async () => {
+      it('renders custom label style', async () => {
         const renderCustomLabel = (): ReactElement => {
           return (
             <Text
@@ -119,7 +119,7 @@ describe('[EditText]', () => {
           expect(label).toHaveStyle({color: 'purple'});
         });
 
-        it('should render error element when provided', async () => {
+        it('renders error element when provided', async () => {
           testingLib = render(
             component({
               testID: 'INPUT_TEST',
@@ -147,7 +147,7 @@ describe('[EditText]', () => {
   });
 
   describe('layout', () => {
-    it('should render [direction] row', () => {
+    it('renders [direction] row', () => {
       testingLib = render(
         component({
           testID: 'INPUT_TEST',
@@ -159,11 +159,10 @@ describe('[EditText]', () => {
       const container = testingLib.getByTestId('container');
 
       expect(input).toBeTruthy();
-
       expect(container).toHaveStyle({flexDirection: 'row'});
     });
 
-    it('should render [decoration] boxed', () => {
+    it('renders [decoration] boxed', () => {
       testingLib = render(
         component({
           testID: 'INPUT_TEST',
@@ -177,6 +176,27 @@ describe('[EditText]', () => {
       expect(input).toBeTruthy();
 
       expect(container).toHaveStyle({borderWidth: 1});
+    });
+  });
+
+  describe('web', () => {
+    beforeAll(() => {
+      jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+        OS: 'web',
+        select: () => null,
+      }));
+    });
+
+    it('renders web style', () => {
+      testingLib = render(
+        component({
+          testID: 'INPUT_TEST',
+        }),
+      );
+
+      const input = testingLib.getByTestId('INPUT_TEST');
+      expect(input).toBeTruthy();
+      expect(input).toHaveStyle({outlineWidth: 0});
     });
   });
 
@@ -198,11 +218,9 @@ describe('[EditText]', () => {
       );
 
       const input = testingLib.getByTestId('INPUT_TEST');
-
       expect(input).toBeTruthy();
 
       fireEvent.changeText(input, CHANGE_TEXT);
-
       expect(mockedFn).toBeCalledWith(CHANGE_TEXT);
     });
 
@@ -253,7 +271,7 @@ describe('[EditText]', () => {
   });
 
   describe('disabled', () => {
-    it('should render [default] disabled style', () => {
+    it('renders [default] disabled style', () => {
       testingLib = render(
         component({
           testID: 'INPUT_TEST',
@@ -268,7 +286,7 @@ describe('[EditText]', () => {
       expect(input).toHaveStyle({color: light.text.disabled});
     });
 
-    it('should render [custom] disabled style', () => {
+    it('renders [custom] disabled style', () => {
       testingLib = render(
         component({
           testID: 'INPUT_TEST',
@@ -319,6 +337,25 @@ describe('[EditText]', () => {
       fireEvent(input, 'focus');
 
       expect(input).toHaveStyle({color: 'yellow'});
+    });
+
+    it('should trigger `onFocus` when touching container', async () => {
+      const focusFn = jest.fn();
+
+      testingLib = render(
+        component({
+          onFocus: focusFn,
+          colors: {focused: 'yellow'},
+        }),
+      );
+
+      const touch = testingLib.getByTestId('container-touch');
+
+      expect(touch).toBeTruthy();
+
+      fireEvent(touch, 'press');
+      // Below should work but no luck in testing-library
+      // expect(focusFn).toBeCalled();
     });
 
     describe('onBlur (focused === false)', () => {

--- a/main/components/EditText/index.tsx
+++ b/main/components/EditText/index.tsx
@@ -1,4 +1,10 @@
-import type {FC, LegacyRef, ReactElement, ReactNode} from 'react';
+import type {
+  FC,
+  MutableRefObject,
+  ReactElement,
+  ReactNode,
+  RefObject,
+} from 'react';
 import {Platform, Text, TextInput, View} from 'react-native';
 import React, {useRef, useState} from 'react';
 import type {
@@ -31,7 +37,7 @@ type RenderType = (stats: EditTextStatus) => ReactElement;
 
 export type EditTextProps = {
   testID?: TextInputProps['testID'];
-  inputRef?: LegacyRef<TextInput>;
+  inputRef?: MutableRefObject<TextInput | undefined> | RefObject<TextInput>;
 
   style?: StyleProp<ViewStyle>;
   styles?: Styles;
@@ -117,7 +123,8 @@ export const EditText: FC<EditTextProps> = (props) => {
   const [focused, setFocused] = useState(false);
   const ref = useRef<View>(null);
   const defaultInputRef = useRef(null);
-  const inputRef = givenInputRef || defaultInputRef;
+  const inputRef =
+    (givenInputRef as MutableRefObject<TextInput>) || defaultInputRef;
   const hovered = useHover(ref);
 
   const defaultContainerStyle: ViewStyle = {
@@ -165,9 +172,8 @@ export const EditText: FC<EditTextProps> = (props) => {
   const renderContainer = (children: ReactNode): ReactElement => {
     return (
       <TouchableWithoutFeedback
-        onPress={() =>
-          (inputRef as React.MutableRefObject<TextInput>).current?.focus()
-        }
+        testID="container-touch"
+        onPress={() => inputRef.current?.focus()}
       >
         <View
           testID="container"
@@ -197,7 +203,7 @@ export const EditText: FC<EditTextProps> = (props) => {
     return (
       <TextInput
         testID={testID}
-        ref={inputRef || defaultInputRef}
+        ref={inputRef}
         autoCapitalize={autoCapitalize}
         secureTextEntry={secureTextEntry}
         style={[

--- a/main/components/EditText/index.tsx
+++ b/main/components/EditText/index.tsx
@@ -178,8 +178,6 @@ export const EditText: FC<EditTextProps> = (props) => {
             borderColor: labelPlaceholderColor
               ? labelPlaceholderColor.color
               : defaultColor,
-            paddingVertical: 12,
-            paddingHorizontal: 10,
           },
           decoration === 'boxed'
             ? {borderWidth: 1, paddingHorizontal: 12}
@@ -205,7 +203,7 @@ export const EditText: FC<EditTextProps> = (props) => {
           // @ts-ignore
           Platform.OS === 'web' && {outlineWidth: 0},
           direction === 'column' ? {paddingTop: 12} : {paddingLeft: 12},
-          {color: defaultColor},
+          {color: defaultColor, paddingVertical: 12},
           styles?.input,
         ]}
         editable={editable}

--- a/main/components/EditText/index.tsx
+++ b/main/components/EditText/index.tsx
@@ -165,27 +165,30 @@ export const EditText: FC<EditTextProps> = (props) => {
   const renderContainer = (children: ReactNode): ReactElement => {
     return (
       <TouchableWithoutFeedback
-        testID="container"
         onPress={() =>
           (inputRef as React.MutableRefObject<TextInput>).current?.focus()
         }
-        style={[
-          defaultContainerStyle,
-          {
-            flexDirection: direction,
-            alignItems: direction === 'row' ? 'center' : 'flex-start',
-            // Default border color follows placeholder color for the label.
-            borderColor: labelPlaceholderColor
-              ? labelPlaceholderColor.color
-              : defaultColor,
-          },
-          decoration === 'boxed'
-            ? {borderWidth: 1, paddingHorizontal: 12}
-            : {borderBottomWidth: 1},
-          styles?.container,
-        ]}
       >
-        {children}
+        <View
+          testID="container"
+          style={[
+            defaultContainerStyle,
+            {
+              flexDirection: direction,
+              alignItems: direction === 'row' ? 'center' : 'flex-start',
+              // Default border color follows placeholder color for the label.
+              borderColor: labelPlaceholderColor
+                ? labelPlaceholderColor.color
+                : defaultColor,
+            },
+            decoration === 'boxed'
+              ? {borderWidth: 1, paddingHorizontal: 12}
+              : {borderBottomWidth: 1},
+            styles?.container,
+          ]}
+        >
+          {children}
+        </View>
       </TouchableWithoutFeedback>
     );
   };

--- a/main/components/EditText/index.tsx
+++ b/main/components/EditText/index.tsx
@@ -8,6 +8,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
 import {useHover} from 'react-native-web-hooks';
 import {useTheme} from '@dooboo-ui/theme';
 
@@ -87,7 +88,7 @@ export type EditTextProps = {
 export const EditText: FC<EditTextProps> = (props) => {
   const {
     testID,
-    inputRef,
+    inputRef: givenInputRef,
     textInputProps,
     style,
     styles,
@@ -115,6 +116,8 @@ export const EditText: FC<EditTextProps> = (props) => {
 
   const [focused, setFocused] = useState(false);
   const ref = useRef<View>(null);
+  const defaultInputRef = useRef(null);
+  const inputRef = givenInputRef || defaultInputRef;
   const hovered = useHover(ref);
 
   const defaultContainerStyle: ViewStyle = {
@@ -161,8 +164,11 @@ export const EditText: FC<EditTextProps> = (props) => {
 
   const renderContainer = (children: ReactNode): ReactElement => {
     return (
-      <View
+      <TouchableWithoutFeedback
         testID="container"
+        onPress={() =>
+          (inputRef as React.MutableRefObject<TextInput>).current?.focus()
+        }
         style={[
           defaultContainerStyle,
           {
@@ -182,7 +188,7 @@ export const EditText: FC<EditTextProps> = (props) => {
         ]}
       >
         {children}
-      </View>
+      </TouchableWithoutFeedback>
     );
   };
 
@@ -190,7 +196,7 @@ export const EditText: FC<EditTextProps> = (props) => {
     return (
       <TextInput
         testID={testID}
-        ref={inputRef}
+        ref={inputRef || defaultInputRef}
         autoCapitalize={autoCapitalize}
         secureTextEntry={secureTextEntry}
         style={[
@@ -263,10 +269,7 @@ export const EditText: FC<EditTextProps> = (props) => {
     <View
       testID="edit-text"
       ref={Platform.select({web: ref, default: undefined})}
-      style={[
-        {alignSelf: 'stretch', padding: 12, flexDirection: 'column'},
-        style,
-      ]}
+      style={[{alignSelf: 'stretch', flexDirection: 'column'}, style]}
     >
       {renderContainer(
         <>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:pre": "mv packages/theme/package.json packages/theme/packages.json",
     "test:post": "mv packages/theme/packages.json packages/theme/package.json",
     "test": "yarn test:pre; jest; yarn test:post;",
-    "test:all": "lerna run build && yarn lint && yarn tsc && yarn test",
+    "test:all": "yarn pre && yarn lint && yarn tsc && yarn test",
     "build": "tsc --project tsconfigBuild.json && yarn cp:icon",
     "cp:icon": "mkdir -p `dirname ./lib/components/Icon/selection.json` && cp ./main/components/Icon/selection.json ./lib/components/Icon/selection.json && cp ./main/components/Icon/doobooui.ttf ./lib/components/Icon/doobooui.ttf",
     "postbuild": "cp ./main/react-native.config.cjs ./lib/react-native.config.cjs && rm -rf ./lib/tsconfig* && cp README.md ./lib/README.md && cp -R main/__assets__ lib",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@dooboo-ui/theme": "^0.10.1",
+    "@dooboo-ui/theme": "^0.10.3",
     "@emotion/native": "^11.10.0",
     "@emotion/react": "^11.10.5",
     "@expo/match-media": "^0.4.0",

--- a/packages/theme/colors.ts
+++ b/packages/theme/colors.ts
@@ -160,7 +160,7 @@ export const dark: typeof light = {
 
 export type Colors = typeof colors;
 
-type StaticTheme = typeof light & {
+export type DoobooTheme = typeof light & {
   isPortrait?: boolean;
   isDesktop?: boolean;
   isTablet?: boolean;
@@ -171,7 +171,7 @@ type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
-export type DoobooTheme = RecursivePartial<StaticTheme>;
+export type DoobooThemeParams = RecursivePartial<DoobooTheme>;
 
 export type ThemeObjParams = {
   bg: Partial<typeof light.bg>;

--- a/packages/theme/index.tsx
+++ b/packages/theme/index.tsx
@@ -1,2 +1,2 @@
 export {ThemeProvider, useTheme, withTheme} from './ThemeProvider';
-export {DoobooTheme, ThemeType, dark, light} from './colors';
+export {DoobooTheme, DoobooThemeParams, ThemeType, dark, light} from './colors';

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dooboo-ui/theme",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "description": "dooboo-ui theme provider",
   "homepage": "https://github.com/dooboolab/dooboo-ui#readme",
   "license": "ISC",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,7 +1877,7 @@
     json5 "^2.2.2"
     write-file-atomic "^2.3.0"
 
-"@expo/match-media@*", "@expo/match-media@^0.4.0":
+"@expo/match-media@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@expo/match-media/-/match-media-0.4.0.tgz#3c2a4bd4978a8c39b475b28f28a6cad47eeb5b3f"
   integrity sha512-8itv719IZJNITYERLQf+aDZJZyM2eigzCwq9Z8pYF9PevJLjQhjS3RJikug+d2MoKvlwwpjiaE1tA+f2hHxsMg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,7 +1877,7 @@
     json5 "^2.2.2"
     write-file-atomic "^2.3.0"
 
-"@expo/match-media@^0.4.0":
+"@expo/match-media@*", "@expo/match-media@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@expo/match-media/-/match-media-0.4.0.tgz#3c2a4bd4978a8c39b475b28f28a6cad47eeb5b3f"
   integrity sha512-8itv719IZJNITYERLQf+aDZJZyM2eigzCwq9Z8pYF9PevJLjQhjS3RJikug+d2MoKvlwwpjiaE1tA+f2hHxsMg==


### PR DESCRIPTION
## Description

Make [EditText] focusable when touching its container. Previously, it did not respond to touches on `label` and other areas.

Change the default styles which focus on `input` rather than the container. It is harder to understand which style to change when we want to remove the default padding.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test:all` and make sure nothing fails.
- [x] I am willing to follow-up on review comments in a timely manner.
