### PR TITLE
refactor duplicate code in docs

### DIFF
--- a/docs/.storybook/darkTheme.js
+++ b/docs/.storybook/darkTheme.js
@@ -11,7 +11,6 @@ export default create({
 
   // UI
   appBg: 'black',
-  // appContentBg: '#111',
   appContentBg: 'black',
   appBorderColor: '#414141',
   appBorderRadius: 1,

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {themes} from '@storybook/theming';
 import {useDarkMode} from 'storybook-dark-mode';
 import {DocsContainer} from '@storybook/addon-docs';
 import darkTheme from './darkTheme';
@@ -63,10 +62,6 @@ export const parameters = {
      */
     hierarchyRootSeparator: /\|/,
     panelPosition: 'bottom',
-  },
-  darkMode: {
-    dark: {...themes.dark},
-    light: {...themes.light},
   },
 };
 

--- a/docs/src/components/Button/Button.stories.mdx
+++ b/docs/src/components/Button/Button.stories.mdx
@@ -150,8 +150,8 @@ The `size` prop can generate many size buttons.
 
 ```tsx
 <Button size="large" text="large" style={{margin: 8}} onPress={() => {}}/>
-<Button size="medium" text="large" style={{margin: 8}} onPress={() => {}}/>
-<Button size="small" text="large" style={{margin: 8}} onPress={() => {}}/>
+<Button size="medium" text="medium" style={{margin: 8}} onPress={() => {}}/>
+<Button size="small" text="small" style={{margin: 8}} onPress={() => {}}/>
 ```
 
 <Sizes />

--- a/docs/src/components/Button/Button.stories.mdx
+++ b/docs/src/components/Button/Button.stories.mdx
@@ -91,13 +91,13 @@ Generate bordering button by adding `outlined` prop.
 
 
 ```tsx
-<Button type="primary" text="Primary" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="secondary" text="Secondary" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="success" text="Success" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="danger" text="Danger" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="warning" text="Warning" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="info" text="Info" outlined style={{margin: 8}} onPress={() => {}} />
-<Button type="light" text="Light" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="primary" text="primary" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="secondary" text="secondary" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="success" text="success" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="danger" text="danger" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="warning" text="warning" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="info" text="info" outlined style={{margin: 8}} onPress={() => {}} />
+<Button type="light" text="light" outlined style={{margin: 8}} onPress={() => {}} />
 ```
 
 <Outlined />

--- a/docs/src/components/Button/Button.stories.mdx
+++ b/docs/src/components/Button/Button.stories.mdx
@@ -71,13 +71,13 @@ The default value of type is `primary`.
 
 
 ```tsx
-<Button type="primary" text="Primary" style={{margin: 8}} onPress={() => {}} />
-<Button type="secondary" text="Secondary" style={{margin: 8}} onPress={() => {}} />
-<Button type="success" text="Success" style={{margin: 8}} onPress={() => {}} />
-<Button type="danger" text="Danger" style={{margin: 8}} onPress={() => {}} />
-<Button type="warning" text="Warning" style={{margin: 8}} onPress={() => {}} />
-<Button type="info" text="Info" style={{margin: 8}} onPress={() => {}} />
-<Button type="light" text="Light" style={{margin: 8}} onPress={() => {}} />
+<Button type="primary" text="primary" style={{margin: 8}} onPress={() => {}} />
+<Button type="secondary" text="secondary" style={{margin: 8}} onPress={() => {}} />
+<Button type="success" text="success" style={{margin: 8}} onPress={() => {}} />
+<Button type="danger" text="danger" style={{margin: 8}} onPress={() => {}} />
+<Button type="warning" text="warning" style={{margin: 8}} onPress={() => {}} />
+<Button type="info" text="info" style={{margin: 8}} onPress={() => {}} />
+<Button type="light" text="light" style={{margin: 8}} onPress={() => {}} />
 ```
 
 <Solid />

--- a/docs/src/components/Button/Outlined.tsx
+++ b/docs/src/components/Button/Outlined.tsx
@@ -1,69 +1,39 @@
 import {Button} from 'dooboo-ui';
+import type {ButtonColorType} from 'dooboo-ui';
 import type {ReactElement} from 'react';
 import {View} from 'react-native';
 import {StoryProvider} from './index';
 
 export default function Outlined(): ReactElement {
+  const colors: ButtonColorType[] = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
+
   return (
     <StoryProvider>
       <View
         style={{
           marginVertical: 8,
-
           flexDirection: 'row',
           flexWrap: 'wrap',
           justifyContent: 'center',
         }}
       >
-        <Button
-          type="outlined"
-          color="primary"
-          text="Primary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          type="outlined"
-          color="secondary"
-          text="Secondary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="success"
-          text="Success"
-          type="outlined"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="danger"
-          text="Danger"
-          type="outlined"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="warning"
-          text="Warning"
-          type="outlined"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="info"
-          text="Info"
-          type="outlined"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="light"
-          text="Light"
-          type="outlined"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
+        {colors.map((color) => (
+          <Button
+            type="outlined"
+            color={color}
+            text={color}
+            style={{margin: 8}}
+            onPress={() => {}}
+          />
+        ))}
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/Button/Sizes.tsx
+++ b/docs/src/components/Button/Sizes.tsx
@@ -1,42 +1,32 @@
-import {Button, useDooboo} from 'dooboo-ui';
+import type {ButtonSizeType} from 'dooboo-ui';
+import {Button} from 'dooboo-ui';
 import type {ReactElement} from 'react';
 import {View} from 'react-native';
 import {StoryProvider} from './index';
 
 export default function Sizes(): ReactElement {
+  const sizes: ButtonSizeType[] = ['large', 'medium', 'small'];
+
   return (
     <StoryProvider>
       <View
         style={{
           marginVertical: 8,
-
           flexDirection: 'row',
           flexWrap: 'wrap',
           justifyContent: 'center',
           alignItems: 'center',
         }}
       >
-        <Button
-          color="primary"
-          size="large"
-          text="Primary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="primary"
-          size="medium"
-          text="Primary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="primary"
-          size="small"
-          text="Primary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
+        {sizes.map((size) => (
+          <Button
+            color="primary"
+            size={size}
+            text={size}
+            style={{margin: 8}}
+            onPress={() => {}}
+          />
+        ))}
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/Button/Solid.tsx
+++ b/docs/src/components/Button/Solid.tsx
@@ -1,9 +1,20 @@
+import type {ButtonColorType} from 'dooboo-ui';
 import {Button} from 'dooboo-ui';
 import type {ReactElement} from 'react';
 import {View} from 'react-native';
 import {StoryProvider} from './index';
 
 export default function Solid(): ReactElement {
+  const colors: ButtonColorType[] = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
+
   return (
     <StoryProvider>
       <View
@@ -14,48 +25,14 @@ export default function Solid(): ReactElement {
           justifyContent: 'center',
         }}
       >
-        <Button
-          color="primary"
-          text="Primary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="secondary"
-          text="Secondary"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="success"
-          text="Success"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="danger"
-          text="Danger"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="warning"
-          text="Warning"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="info"
-          text="Info"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
-        <Button
-          color="light"
-          text="Light"
-          style={{margin: 8}}
-          onPress={() => {}}
-        />
+        {colors.map((color) => (
+          <Button
+            color={color}
+            text={color}
+            style={{margin: 8}}
+            onPress={() => {}}
+          />
+        ))}
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/Checkbox/Checkbox.stories.mdx
+++ b/docs/src/components/Checkbox/Checkbox.stories.mdx
@@ -111,16 +111,6 @@ It can be used with the `type` prop.
   onPress={() => setChecked(!checked)}
   startElement={<StyledText>Hello this is a checkbox</StyledText>}
 />
-<Checkbox
-  checked={checked}
-  onPress={() => setChecked(!checked)}
-  startElement={<StyledText>Hello this is a checkbox</StyledText>}
-/>
-<Checkbox
-  checked={checked}
-  onPress={() => setChecked(!checked)}
-  startElement={<StyledText>Hello this is a checkbox</StyledText>}
-/>
 ```
 
 <StartElement />
@@ -133,16 +123,6 @@ The `endElement` prop can generate Checkbox in front of the element.
 It can be used with the `type` prop.
 
 ```tsx
-<Checkbox
-  checked={checked}
-  onPress={() => setChecked(!checked)}
-  endElement={<StyledText>Hello this is a checkbox</StyledText>}
-/>
-<Checkbox
-  checked={checked}
-  onPress={() => setChecked(!checked)}
-  endElement={<StyledText>Hello this is a checkbox</StyledText>}
-/>
 <Checkbox
   checked={checked}
   onPress={() => setChecked(!checked)}

--- a/docs/src/components/Checkbox/EndElement.tsx
+++ b/docs/src/components/Checkbox/EndElement.tsx
@@ -45,23 +45,11 @@ export default function EndElement(): ReactElement {
           padding: 10,
         }}
       >
-        <View style={{flexDirection: 'column'}}>
-          <Checkbox
-            checked={checked}
-            onPress={() => setChecked(!checked)}
-            endElement={<StyledText>Hello this is a checkbox</StyledText>}
-          />
-          <Checkbox
-            checked={checked}
-            onPress={() => setChecked(!checked)}
-            endElement={<StyledText>Hello this is a checkbox</StyledText>}
-          />
-          <Checkbox
-            checked={checked}
-            onPress={() => setChecked(!checked)}
-            endElement={<StyledText>Hello this is a checkbox</StyledText>}
-          />
-        </View>
+        <Checkbox
+          checked={checked}
+          onPress={() => setChecked(!checked)}
+          endElement={<StyledText>Hello this is a checkbox</StyledText>}
+        />
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/Checkbox/StartElement.tsx
+++ b/docs/src/components/Checkbox/StartElement.tsx
@@ -41,21 +41,10 @@ export default function StartElement(): ReactElement {
         style={{
           flex: 1,
           alignSelf: 'stretch',
-          flexDirection: 'column',
           alignItems: 'center',
           padding: 10,
         }}
       >
-        <Checkbox
-          checked={checked}
-          onPress={() => setChecked(!checked)}
-          startElement={<StyledText>Hello this is a checkbox</StyledText>}
-        />
-        <Checkbox
-          checked={checked}
-          onPress={() => setChecked(!checked)}
-          startElement={<StyledText>Hello this is a checkbox</StyledText>}
-        />
         <Checkbox
           checked={checked}
           onPress={() => setChecked(!checked)}

--- a/docs/src/components/RadioGroup/Basic.tsx
+++ b/docs/src/components/RadioGroup/Basic.tsx
@@ -8,7 +8,7 @@ import {StoryProvider} from './index';
 const data = ['one', 'two', 'three', 'four'];
 
 export default function Basic(): ReactElement {
-  const [curValue, setCurValue] = useState<string>(data[0]);
+  const [selectedValue, setSelectedValue] = useState<string>(data[0]);
 
   return (
     <StoryProvider>
@@ -22,8 +22,8 @@ export default function Basic(): ReactElement {
       >
         <RadioGroup
           data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
+          selectedValue={selectedValue}
+          selectValue={setSelectedValue}
         />
       </View>
     </StoryProvider>

--- a/docs/src/components/RadioGroup/Colored.tsx
+++ b/docs/src/components/RadioGroup/Colored.tsx
@@ -1,3 +1,4 @@
+import type {RadioButtonType} from 'dooboo-ui';
 import {RadioGroup} from 'dooboo-ui';
 
 import type {ReactElement} from 'react';
@@ -8,7 +9,17 @@ import {StoryProvider} from './index';
 const data = ['one', 'two', 'three', 'four'];
 
 export default function Colored(): ReactElement {
-  const [curValue, setCurValue] = useState<string>(data[0]);
+  const [selectedValue, setSelectedValue] = useState<string>(data[0]);
+
+  const colors: RadioButtonType = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
 
   return (
     <StoryProvider>
@@ -20,49 +31,15 @@ export default function Colored(): ReactElement {
           padding: 15,
         }}
       >
-        <RadioGroup
-          title="Primary"
-          type="primary"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
-        <RadioGroup
-          title="Secondary"
-          type="secondary"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
-        <RadioGroup
-          title="Success"
-          type="success"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
-        <RadioGroup
-          title="Warning"
-          type="warning"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
-
-        <RadioGroup
-          title="Info"
-          type="info"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
-        <RadioGroup
-          title="Danger"
-          type="danger"
-          data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
-        />
+        {colors.map((color) => (
+          <RadioGroup
+            title={color}
+            type={color}
+            data={data}
+            selectedValue={selectedValue}
+            selectValue={setSelectedValue}
+          />
+        ))}
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/docs/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -53,7 +53,7 @@ With `title` prop, you can add a title to [RadioGroup].
 If no specific styles added, the title is shown top-left of the radio buttons.
 
 ```tsx
-<RadioGroup title={title} data={data} selectedValue={selectedValue} />
+<RadioGroup title="Title" data={data} selectedValue={selectedValue} />
 ```
 
 <WithTitle />
@@ -154,7 +154,7 @@ const [selectedValue, setSelectedValue] = useState(data[0]);
     data={data}
     labels={labels}
     selectedValue={selectedValue}
-    selectValue={(value) => setSelectedValue(value)}
+    selectValue={setSelectedValue}
   />
 ))}
 ```

--- a/docs/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/docs/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -93,12 +93,32 @@ You can change the color of the selected button with `type` prop. The default va
 is set to `primary`.
 
 ```tsx
-<RadioGroup
-  type="primary"
-  title="Primary"
-  data={data}
-  selectedValue={selectedValue}
-/>
+import type {RadioButtonType} from 'dooboo-ui';
+import {useState} from 'react';
+
+const data = ['one', 'two', 'three', 'four'];
+
+const colors: RadioButtonType = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
+
+const [selectedValue, setSelectedValue] = useState<string>(data[0]);
+
+{colors.map((color) => (
+  <RadioGroup
+    title={color}
+    type={color}
+    data={data}
+    selectedValue={selectedValue}
+    selectValue={setSelectedValue}
+  />
+))}
 ```
 
 <Colored />
@@ -109,21 +129,34 @@ You should set `selectValue` prop appropriately to make [RadioGroup] component w
 This is a simple example of setting `selectValue` prop using react hooks.
 
 ```tsx
+import type {RadioButtonType} from 'dooboo-ui';
 import {useState} from 'react';
 
 const data = ['one', 'two', 'three', 'four'];
 const labels = ['One', 'Two', 'Three', 'Four'];
 
+const colors: RadioButtonType = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
+
 const [selectedValue, setSelectedValue] = useState(data[0]);
 
-<RadioGroup
-  title="Primary"
-  type="primary"
-  data={data}
-  labels={labels}
-  selectedValue={selectedValue}
-  selectValue={(value) => setSelectedValue(value)}
-/>;
+{colors.map((color) => (
+  <RadioGroup
+    title={color}
+    type={color}
+    data={data}
+    labels={labels}
+    selectedValue={selectedValue}
+    selectValue={(value) => setSelectedValue(value)}
+  />
+))}
 ```
 
 <SelectValue />

--- a/docs/src/components/RadioGroup/SelectValue.tsx
+++ b/docs/src/components/RadioGroup/SelectValue.tsx
@@ -39,7 +39,7 @@ export default function SelectValue(): ReactElement {
             data={data}
             labels={labels}
             selectedValue={selectedValue}
-            selectValue={(value) => setSelectedValue(value)}
+            selectValue={setSelectedValue}
             styles={{container: {paddingBottom: 5}}}
           />
         ))}

--- a/docs/src/components/RadioGroup/SelectValue.tsx
+++ b/docs/src/components/RadioGroup/SelectValue.tsx
@@ -1,3 +1,4 @@
+import type {RadioButtonType} from 'dooboo-ui';
 import {RadioGroup} from 'dooboo-ui';
 import React, {useState} from 'react';
 
@@ -11,6 +12,16 @@ const labels = ['One', 'Two', 'Three', 'Four'];
 export default function SelectValue(): ReactElement {
   const [selectedValue, setSelectedValue] = useState<string>(data[0]);
 
+  const colors: RadioButtonType = [
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'danger',
+    'info',
+    'light',
+  ];
+
   return (
     <StoryProvider>
       <View
@@ -21,61 +32,17 @@ export default function SelectValue(): ReactElement {
           padding: 15,
         }}
       >
-        <RadioGroup
-          title="Primary"
-          type="primary"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
-        <RadioGroup
-          title="Secondary"
-          type="secondary"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
-        <RadioGroup
-          title="Success"
-          type="success"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
-        <RadioGroup
-          title="Warning"
-          type="warning"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
-
-        <RadioGroup
-          title="Info"
-          type="info"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
-        <RadioGroup
-          title="Danger"
-          type="danger"
-          data={data}
-          labels={labels}
-          selectedValue={selectedValue}
-          selectValue={(value) => setSelectedValue(value)}
-          styles={{container: {paddingBottom: 5}}}
-        />
+        {colors.map((color) => (
+          <RadioGroup
+            title={color}
+            type={color}
+            data={data}
+            labels={labels}
+            selectedValue={selectedValue}
+            selectValue={(value) => setSelectedValue(value)}
+            styles={{container: {paddingBottom: 5}}}
+          />
+        ))}
       </View>
     </StoryProvider>
   );

--- a/docs/src/components/RadioGroup/WithLabels.tsx
+++ b/docs/src/components/RadioGroup/WithLabels.tsx
@@ -13,7 +13,7 @@ type WithLabelsProps = {labelPosition: 'left' | 'right'};
 export default function WithLabels({
   labelPosition,
 }: WithLabelsProps): ReactElement {
-  const [curValue, setCurValue] = useState<string>(data[0]);
+  const [selectedValue, setSelectedValue] = useState<string>(data[0]);
 
   return (
     <StoryProvider>
@@ -29,8 +29,8 @@ export default function WithLabels({
           data={data}
           labels={labels}
           labelPosition={labelPosition}
-          selectedValue={curValue}
-          selectValue={setCurValue}
+          selectedValue={selectedValue}
+          selectValue={setSelectedValue}
         />
       </View>
     </StoryProvider>

--- a/docs/src/components/RadioGroup/WithTitle.tsx
+++ b/docs/src/components/RadioGroup/WithTitle.tsx
@@ -8,7 +8,7 @@ import {StoryProvider} from './index';
 const data = ['one', 'two', 'three', 'four'];
 
 export default function WithTitle(): ReactElement {
-  const [curValue, setCurValue] = useState<string>(data[0]);
+  const [selectedValue, setSelectedValue] = useState<string>(data[0]);
 
   return (
     <StoryProvider>
@@ -23,8 +23,8 @@ export default function WithTitle(): ReactElement {
         <RadioGroup
           title="Title"
           data={data}
-          selectedValue={curValue}
-          selectValue={setCurValue}
+          selectedValue={selectedValue}
+          selectValue={setSelectedValue}
         />
       </View>
     </StoryProvider>

--- a/main/uis/RadioGroup/RadioButton.tsx
+++ b/main/uis/RadioGroup/RadioButton.tsx
@@ -12,6 +12,7 @@ import {
 } from '../Styled/StyledComponents';
 import type {FC} from 'react';
 import React, {useEffect, useRef, useState} from 'react';
+import {RadioButtonType} from './index';
 
 import styled from '@emotion/native';
 
@@ -19,14 +20,6 @@ type Styles = {
   radio?: StyleProp<ViewStyle>;
   label?: StyleProp<TextStyle>;
 };
-
-export type RadioButtonType =
-  | 'primary'
-  | 'secondary'
-  | 'success'
-  | 'danger'
-  | 'warning'
-  | 'info';
 
 export type RadioButtonProps = {
   testID?: string;

--- a/main/uis/RadioGroup/index.tsx
+++ b/main/uis/RadioGroup/index.tsx
@@ -1,4 +1,4 @@
-import type {RadioButtonProps, RadioButtonType} from './RadioButton';
+import type {RadioButtonProps} from './RadioButton';
 import type {StyleProp, TextStyle, ViewStyle} from 'react-native';
 
 import {Heading3} from '../Typography/Typography';
@@ -12,6 +12,15 @@ type Styles = {
   title?: StyleProp<TextStyle>;
   label?: StyleProp<TextStyle>;
 };
+
+export type RadioButtonType =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'light';
 
 type Props<T> = {
   title?: string;

--- a/stories/uis/RadioGroupStories/RadioGroupBasicStory.tsx
+++ b/stories/uis/RadioGroupStories/RadioGroupBasicStory.tsx
@@ -2,7 +2,7 @@
 import React, {useState} from 'react';
 import {ScrollContainer, StoryContainer, StoryTitle} from '../../GlobalStyles';
 
-import type {RadioButtonType} from '../../../main/uis/RadioGroup/RadioButton';
+import type {RadioButtonType} from '../../../main/uis/RadioGroup';
 import {RadioGroup} from '../../../main';
 import type {ReactElement} from 'react';
 import {View} from 'react-native';

--- a/stories/uis/RadioGroupStories/RadioGroupElementStory.tsx
+++ b/stories/uis/RadioGroupStories/RadioGroupElementStory.tsx
@@ -2,7 +2,7 @@
 import React, {useState} from 'react';
 import {ScrollContainer, StoryContainer, StoryTitle} from '../../GlobalStyles';
 
-import type {RadioButtonType} from '../../../main/uis/RadioGroup/RadioButton';
+import type {RadioButtonType} from '../../../main/uis/RadioGroup';
 import {RadioGroup} from '../../../main';
 import type {ReactElement} from 'react';
 import {View} from 'react-native';


### PR DESCRIPTION
## Description

Remove duplicate code from /docs. 
And, Move the RadioButtonType in `/main/uis/RadioGroup`: For `import type {RadioButtonType} from 'dooboo-ui';`

https://github.com/dooboolab/dooboo-ui/pull/246



## Checklist

- [x] remove unnecessary  code in `/docs/.storybook/darkTheme.js`, `/docs/.storybook/preview.js`
- [x] Button > Solid, Outlined, Sizes
- [x] Checkbox > StartElement, EndElement
- [x] move RadioButtonType in `/main/uis/RadioGroup`
- [x] RadioGroup > Colored, SelectValue
