### PR TITLE
refactor: apply brand title, url, image

### DIFF
--- a/docs/.storybook/darkTheme.js
+++ b/docs/.storybook/darkTheme.js
@@ -7,12 +7,12 @@ export default create({
   brandImage: '/assets/icon.png',
 
   colorPrimary: 'white',
-  colorSecondary: '#00D9D5',
+  colorSecondary: '#585DFA',
 
   // UI
   appBg: 'black',
   appContentBg: 'black',
-  appBorderColor: '#414141',
+  appBorderColor: '#1E1E1E',
   appBorderRadius: 1,
 
   // Typography
@@ -24,9 +24,9 @@ export default create({
   textInverseColor: 'black',
 
   // Toolbar default and active colors
-  barTextColor: '#414141',
-  barSelectedColor: 'white',
-  barBg: '#33FF2F',
+  barTextColor: '#EDEDED',
+  barSelectedColor: '#585DFA',
+  barBg: 'black',
 
   // Form colors
   inputBg: 'black',

--- a/docs/.storybook/lightTheme.js
+++ b/docs/.storybook/lightTheme.js
@@ -7,12 +7,12 @@ export default create({
   brandImage: '/assets/icon.png',
 
   colorPrimary: 'black',
-  colorSecondary: '#00D9D5',
+  colorSecondary: '#47498A',
 
   // UI
   appBg: 'white',
   appContentBg: 'white',
-  appBorderColor: '#F6F9FC',
+  appBorderColor: '#EDEDED',
   appBorderRadius: 1,
 
   // Typography
@@ -24,9 +24,9 @@ export default create({
   textInverseColor: 'white',
 
   // Toolbar default and active colors
-  barTextColor: '#F6F9FC',
-  barSelectedColor: 'black',
-  barBg: '#33FF2F',
+  barTextColor: '#1E1E1E',
+  barSelectedColor: '#47498A',
+  barBg: 'white',
 
   // Form colors
   inputBg: 'white',

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -63,6 +63,10 @@ export const parameters = {
     hierarchyRootSeparator: /\|/,
     panelPosition: 'bottom',
   },
+  darkMode: {
+    dark: darkTheme,
+    light: lightTheme,
+  },
 };
 
 export const decorators = [(Story) => <Story />];


### PR DESCRIPTION
## Description

Apply brand title, url, image. 
and change  `colorSecondary`, `barSelectedColor` to dooboo-ui primary color.


## Tests
<img width="626" alt="스크린샷 2023-03-07 오후 7 09 52" src="https://user-images.githubusercontent.com/19985265/223392218-ca7e29fb-3ee7-453b-96dd-596d1b3a39bb.png">
<img width="653" alt="스크린샷 2023-03-07 오후 7 09 35" src="https://user-images.githubusercontent.com/19985265/223392245-3712dede-05f7-42db-85f4-d3fa157c701c.png">

